### PR TITLE
[codex] Add WeChat 268596 patch support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ swift run wechat-antirecall install --with-tip --block-update --dry-run --app /A
 
 **第三步**：确认无误后安装。
 
+安装前请先完全退出微信。不要在微信仍运行时写入补丁；否则已启动的进程可能在执行到被修改过的代码页时被 macOS 以 `Code Signature Invalid` 终止。
+
 ```bash
 swift build -c release
 
@@ -78,6 +80,8 @@ sudo sh -c 'id -u; touch /Applications/WeChat.app/Contents/Resources/.wechat-ant
 ```
 
 如果上面的命令第一行输出 `0`，但 `touch` 仍然报 `Operation not permitted`，说明 `sudo` 已生效，写入被 macOS 隐私权限拦截。到 **System Settings → Privacy & Security → App Management** 中给当前运行命令的应用开启权限，例如 Terminal、iTerm、VS Code、Cursor 或 Codex；必要时也在 **Full Disk Access** 中开启同一个应用。改完后退出并重新打开终端，再重新运行 release 安装命令。
+
+如果工具提示 `WeChat 仍在运行`，请先退出微信后再安装或恢复。这个检查会阻止在运行中的 app bundle 上打补丁，避免旧进程因为代码签名页校验失败而崩溃。
 
 安装时默认在被 patch 的二进制旁边创建备份，文件名格式：
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ macOS 微信 4 防撤回补丁工具。参考 WeChatTweak 的版本配置和 Mac
 | 31927, 31960, 32281, 32288, 34371 | arm64 | `Contents/MacOS/WeChat` |
 | 34817 | x86_64 | `Contents/MacOS/WeChat` |
 | 36559 | x86_64 | `Contents/Frameworks/wechat.dylib` |
-| 268575 | arm64 | `Contents/Resources/wechat.dylib` |
+| 268575, 268596 | arm64 | `Contents/Resources/wechat.dylib` |
 
-> **268575（微信 4.1.9）** 的补丁目标在 `wechat.dylib`，不是主二进制。该 dylib 不会被 `codesign --deep` 自动作为嵌套代码处理，工具会先单独重签被 patch 的 dylib，再重签整个 app，否则运行到撤回消息所在代码页时 macOS 会以 `Code Signature Invalid` 杀掉微信。
+> **268575 / 268596（微信 4.1.9）** 的补丁目标在 `wechat.dylib`，不是主二进制。该 dylib 不会被 `codesign --deep` 自动作为嵌套代码处理，工具会先单独重签被 patch 的 dylib，再重签整个 app，否则运行到撤回消息所在代码页时 macOS 会以 `Code Signature Invalid` 杀掉微信。
 
 ## 补丁模式
 
@@ -137,7 +137,7 @@ sudo .build/release/wechat-antirecall restore \
 
 `expected` 支持单个十六进制字符串或字符串数组；提示模式会同时接受"原始字节"和"已装过静默补丁的字节"，支持直接在两种模式间切换而无需先恢复备份。
 
-`update` 目标目前只覆盖 `268575`（微信 4.1.9 arm64），核心是让更新入口提前返回，并把更新权限相关 getter 固定为 `false`。
+`update` 目标目前覆盖 `268575` / `268596`（微信 4.1.9 arm64），核心是让更新入口提前返回，并把更新权限相关 getter 固定为 `false`。
 
 ## 参考
 

--- a/Sources/WeChatAntiRecall/main.swift
+++ b/Sources/WeChatAntiRecall/main.swift
@@ -24,6 +24,7 @@ enum ToolError: LocalizedError {
     case commandFailed(String, Int32)
     case permissionDenied(path: String, operation: String)
     case fileOperationFailed(operation: String, path: String, underlying: String)
+    case appIsRunning(path: String, pids: [String])
 
     var errorDescription: String? {
         switch self {
@@ -62,6 +63,12 @@ enum ToolError: LocalizedError {
             \(operation)失败：\(path)
             底层错误：\(underlying)
             当前有效用户 ID：\(geteuid())。如果已经通过 sudo 运行但底层错误是 Operation not permitted，请在 macOS 系统设置的 Privacy & Security 中给当前终端应用开启 App Management，必要时同时开启 Full Disk Access，然后退出并重新打开终端再试。
+            """
+        case .appIsRunning(let path, let pids):
+            return """
+            WeChat 仍在运行，不能在运行中修改或恢复 app bundle：\(path)
+            正在运行的进程 PID：\(pids.joined(separator: ", "))
+            请先完全退出微信，再重新运行命令。运行中修改二进制可能触发 macOS Code Signature Invalid 崩溃。
             """
         }
     }
@@ -244,6 +251,7 @@ struct CLI {
         print("WeChat: \(appInfo.shortVersion) (\(appInfo.buildVersion))")
         let modeText = targetIdentifiers.map(displayName(forTargetIdentifier:)).joined(separator: ", ")
         print(options.dryRun ? "Mode: dry-run (\(modeText))" : "Mode: \(modeText)")
+        try ensureAppNotRunning(appInfo: appInfo, dryRun: options.dryRun)
         try validateInstallPermissions(appInfo: appInfo, targets: targets, options: options)
 
         for target in targets {
@@ -297,6 +305,7 @@ struct CLI {
             throw ToolError.usage("备份文件不存在：\(backupURL.path)")
         }
 
+        try ensureAppNotRunning(appInfo: appInfo, dryRun: false)
         let data = try Data(contentsOf: backupURL)
         try validateRestorePermissions(appInfo: appInfo, binaryURL: binaryURL, skipResign: options.skipResign)
         try data.write(to: binaryURL, options: .atomic)
@@ -695,6 +704,47 @@ private func validateRestorePermissions(appInfo: AppInfo, binaryURL: URL, skipRe
 
     if !skipResign {
         try requireDirectoryWritable(appInfo.appURL, operation: "重签名 WeChat.app")
+    }
+}
+
+private func ensureAppNotRunning(appInfo: AppInfo, dryRun: Bool) throws {
+    guard !dryRun else {
+        return
+    }
+
+    let appPath = appInfo.appURL.standardizedFileURL.path
+    let appPrefix = appPath.hasSuffix("/") ? appPath : "\(appPath)/"
+    let process = Process()
+    let pipe = Pipe()
+    process.executableURL = URL(fileURLWithPath: "/bin/ps")
+    process.arguments = ["-axo", "pid=,comm="]
+    process.standardOutput = pipe
+    process.standardError = Pipe()
+
+    try process.run()
+    process.waitUntilExit()
+    guard process.terminationStatus == 0 else {
+        throw ToolError.commandFailed("/bin/ps -axo pid=,comm=", process.terminationStatus)
+    }
+
+    let output = pipe.fileHandleForReading.readDataToEndOfFile()
+    let text = String(data: output, encoding: .utf8) ?? ""
+    let runningPIDs = text.split(separator: "\n").compactMap { line -> String? in
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        guard let separator = trimmed.firstIndex(where: { $0 == " " || $0 == "\t" }) else {
+            return nil
+        }
+
+        let pid = String(trimmed[..<separator])
+        let command = String(trimmed[separator...]).trimmingCharacters(in: .whitespaces)
+        if command == appPath || command.hasPrefix(appPrefix) {
+            return pid
+        }
+        return nil
+    }
+
+    if !runningPIDs.isEmpty {
+        throw ToolError.appIsRunning(path: appInfo.appURL.path, pids: runningPIDs)
     }
 }
 

--- a/patches.json
+++ b/patches.json
@@ -202,5 +202,103 @@
         ]
       }
     ]
+  },
+  {
+    "version": "268596",
+    "targets": [
+      {
+        "identifier": "revoke",
+        "binary": "Contents/Resources/wechat.dylib",
+        "entries": [
+          {
+            "arch": "arm64",
+            "addr": "47647a0",
+            "expected": "E00F0034",
+            "asm": "7F000014"
+          }
+        ]
+      },
+      {
+        "identifier": "revoke-tip",
+        "binary": "Contents/Resources/wechat.dylib",
+        "entries": [
+          {
+            "arch": "arm64",
+            "addr": "47647a0",
+            "expected": [
+              "E00F0034",
+              "7F000014"
+            ],
+            "asm": "E00F0034"
+          },
+          {
+            "arch": "arm64",
+            "addr": "4764f34",
+            "expected": "60B600F9",
+            "asm": "7FB600F9"
+          }
+        ]
+      },
+      {
+        "identifier": "update",
+        "binary": "Contents/Resources/wechat.dylib",
+        "entries": [
+          {
+            "arch": "arm64",
+            "addr": "1c5f24",
+            "expected": "FC6FBBA9",
+            "asm": "C0035FD6"
+          },
+          {
+            "arch": "arm64",
+            "addr": "1c8140",
+            "expected": "FFC305D1",
+            "asm": "C0035FD6"
+          },
+          {
+            "arch": "arm64",
+            "addr": "1c8410",
+            "expected": "FF4301D1",
+            "asm": "C0035FD6"
+          },
+          {
+            "arch": "arm64",
+            "addr": "1c8830",
+            "expected": "F657BDA9",
+            "asm": "C0035FD6"
+          },
+          {
+            "arch": "arm64",
+            "addr": "1ca728",
+            "expected": "FFC305D1",
+            "asm": "C0035FD6"
+          },
+          {
+            "arch": "arm64",
+            "addr": "1cf248",
+            "expected": "00604039C0035FD6",
+            "asm": "00008052C0035FD6"
+          },
+          {
+            "arch": "arm64",
+            "addr": "1cf250",
+            "expected": "02600039",
+            "asm": "C0035FD6"
+          },
+          {
+            "arch": "arm64",
+            "addr": "1cf258",
+            "expected": "00644039C0035FD6",
+            "asm": "00008052C0035FD6"
+          },
+          {
+            "arch": "arm64",
+            "addr": "1cf260",
+            "expected": "02640039",
+            "asm": "C0035FD6"
+          }
+        ]
+      }
+    ]
   }
 ]


### PR DESCRIPTION
## Summary

- Add arm64 patch entries for WeChat build 268596 / 4.1.9.52.
- Cover silent revoke, revoke-with-tip, and update blocking targets in `Contents/Resources/wechat.dylib`.
- Refuse non-dry-run install/restore while WeChat processes from the target app bundle are still running, avoiding Code Signature Invalid crashes from patching a live app.
- Update README support and install safety notes for 268596.

## Validation

- `python3 -m json.tool patches.json`
- `git diff --check`
- `swiftc -parse-as-library Sources/WeChatAntiRecall/main.swift -o /tmp/wechat-antirecall`
- `/tmp/wechat-antirecall versions --app /Applications/WeChat.app --config patches.json`
- `/tmp/wechat-antirecall install --with-tip --block-update --dry-run --app /Applications/WeChat.app --config patches.json`
- Real install on WeChat 4.1.9 (268596) with `--with-tip --block-update` succeeded; backup created and all patch entries applied.
- `codesign --verify --strict --verbose=2 /Applications/WeChat.app/Contents/Resources/wechat.dylib`
- `codesign --verify --deep --strict --verbose=2 /Applications/WeChat.app`
- Post-install dry-run reports all 268596 entries as `already patched`.
- Running-process guard verified: non-dry-run install now refuses while WeChat PIDs from the target app bundle are active.

Note: `swift build -c release` is currently blocked in my local Command Line Tools environment by a `PackageDescription` manifest link error before compiling package sources.