### PR TITLE
完善微信 4.1.9 支持：新增 268599 适配、优化自定义撤回提示并引入 clone/split 分身多开

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,5 +26,6 @@ let package = Package(
                 "WeChatAntiRecallRuntime"
             ]
         )
-    ]
+    ],
+    cxxLanguageStandard: .cxx17
 )

--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ macOS 微信 4 防撤回补丁工具。参考 WeChatTweak 的版本配置和 Mac
 | 31927, 31960, 32281, 32288, 34371 | arm64 | `Contents/MacOS/WeChat` |
 | 34817 | x86_64 | `Contents/MacOS/WeChat` |
 | 36559 | x86_64 | `Contents/Frameworks/wechat.dylib` |
-| 268575 | arm64 | `multiInstance` 在 `Contents/MacOS/WeChat` |
-| 268575, 268596, 268597 | arm64 | `Contents/Resources/wechat.dylib` |
-| 268597 | arm64 | 自定义撤回提示运行时 `--runtime-tip` |
+| 268575, 268599 | arm64 | `multiInstance` 在 `Contents/MacOS/WeChat` |
+| 268575, 268596, 268597, 268599 | arm64 | `Contents/Resources/wechat.dylib` |
+| 268597, 268599 | arm64 | 自定义撤回提示运行时 `--runtime-tip` |
 
-> **268575 / 268596 / 268597（微信 4.1.9）** 的补丁目标在 `wechat.dylib`，不是主二进制。该 dylib 不会被 `codesign --deep` 自动作为嵌套代码处理，工具会先单独重签被 patch 的 dylib，再重签整个 app，否则运行到撤回消息所在代码页时 macOS 会以 `Code Signature Invalid` 杀掉微信。
+> **268575 / 268596 / 268597 / 268599（微信 4.1.9）** 的补丁目标在 `wechat.dylib`，不是主二进制。该 dylib 不会被 `codesign --deep` 自动作为嵌套代码处理，工具会先单独重签被 patch 的 dylib，再重签整个 app，否则运行到撤回消息所在代码页时 macOS 会以 `Code Signature Invalid` 杀掉微信。
 
-> **268575（微信 4.1.9）** 的 `multiInstance` 目标在主二进制 `Contents/MacOS/WeChat`。其中 dylib 不会被 `codesign --deep` 自动作为嵌套代码处理，工具会先单独重签被 patch 的 dylib，再重签整个 app，否则运行到撤回消息所在代码页时 macOS 会以 `Code Signature Invalid` 杀掉微信
+> **268575 / 268599（微信 4.1.9）** 的 `multiInstance` 目标在主二进制 `Contents/MacOS/WeChat`。其中 dylib 不会被 `codesign --deep` 自动作为嵌套代码处理，工具会先单独重签被 patch 的 dylib，再重签整个 app，否则运行到撤回消息所在代码页时 macOS 会以 `Code Signature Invalid` 杀掉微信
 
 ## 补丁模式
 
@@ -26,9 +26,9 @@ macOS 微信 4 防撤回补丁工具。参考 WeChatTweak 的版本配置和 Mac
 
 **提示模式（`--with-tip`）**：不跳过 `revokemsg` 解析，让微信继续读取 `replacemsg` 撤回提示，同时把撤回包里的 `newmsgid` 清零，阻止微信按原消息 SvrID 删除已有消息。效果与 BetterWX/WeChatTweak 的"保留提示、阻断删除"策略一致。
 
-**自定义撤回提示短语（`tip-phrase` + `--runtime-tip`）**：提供 X1a0He 风格的短语配置入口，支持 `{from}` 占位符和本地预览。`tip-phrase` 写入当前登录用户的 WeChat 容器偏好文件，请用普通用户执行，不要用 `sudo`。`--runtime-tip` 会把运行时 dylib 安装到 `Contents/Resources`，并给 `wechat.dylib` 注入 `LC_LOAD_DYLIB`，让撤回提示改用配置短语；目前只支持构建号 `268597`。
+**自定义撤回提示短语（`tip-phrase` + `--runtime-tip`）**：提供 X1a0He 风格的短语配置入口，支持 `{from}` 占位符和本地预览。`tip-phrase` 写入当前登录用户的 WeChat 容器偏好文件，请用普通用户执行，不要用 `sudo`。`--runtime-tip` 会把运行时 dylib 安装到 `Contents/Resources`，并给 `wechat.dylib` 注入 `LC_LOAD_DYLIB`，让撤回提示改用配置短语；目前支持构建号 `268597` / `268599`。
 
-**无限多开（`--multi-instance`）**：绕过微信 4.1.9 进程互斥检查，允许同时启动多个客户端实例（当前仅 `268575` 提供该目标）。
+**无限多开（`--multi-instance`）**：绕过微信 4.1.9 进程互斥检查，允许同时启动多个客户端实例（当前支持 `268575` / `268599`）。
 
 <u>使用方法：选择带有多开参数的命令安装后，使用命令 `open -n /Applications/WeChat.app` 或者 使用多开启动器： [WeChatMulti](https://github.com/loohalh/WeChatMulti)</u>
 
@@ -120,7 +120,7 @@ sudo .build/release/wechat-antirecall install --app /Applications/WeChat.app
 # 提示模式
 sudo .build/release/wechat-antirecall install --with-tip --app /Applications/WeChat.app
 
-# 自定义撤回提示短语（仅 268597）
+# 自定义撤回提示短语（仅 268597 / 268599）
 sudo .build/release/wechat-antirecall install --runtime-tip --app /Applications/WeChat.app
 
 # 提示模式 + 多开
@@ -214,9 +214,9 @@ sudo .build/release/wechat-antirecall restore \
 
 `expected` 支持单个十六进制字符串或字符串数组；提示模式会同时接受"原始字节"和"已装过静默补丁的字节"，支持直接在两种模式间切换而无需先恢复备份。
 
-`multiInstance` 目标目前只覆盖 `268575`（微信 4.1.9），当前提供 arm64 地址（主二进制 `Contents/MacOS/WeChat`）。
+`multiInstance` 目标目前覆盖 `268575` / `268599`（微信 4.1.9），当前提供 arm64 地址（主二进制 `Contents/MacOS/WeChat`）。
 
-`update` 目标目前覆盖 `268575` / `268596` / `268597`（微信 4.1.9 arm64），核心是让更新入口提前返回，并把更新权限相关 getter 固定为 `false`。
+`update` 目标目前覆盖 `268575` / `268596` / `268597` / `268599`（微信 4.1.9 arm64），核心是让更新入口提前返回，并把更新权限相关 getter 固定为 `false`。
 
 显式请求 `--with-tip` 或 `--block-update` 时，当前构建号必须提供对应的 `revoke-tip` 或 `update` 目标；工具会拒绝静默降级成其他模式。
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 macOS 微信 4 防撤回补丁工具。参考 WeChatTweak 的版本配置和 Mach-O 地址补丁思路，默认只处理 `revoke` 目标，版本未知时拒绝写入。
 
 ## 更新
-- 2026.5.11 增加 268575（微信 4.1.9） 多开 
+- 2026.5.13 增加 `clone` / `split` 分身多开命令，推荐替代 `open -n` 方案
+- 2026.5.11 增加 268575（微信 4.1.9） 多开
 
 ## 支持的版本
 
@@ -28,10 +29,9 @@ macOS 微信 4 防撤回补丁工具。参考 WeChatTweak 的版本配置和 Mac
 
 **自定义撤回提示短语（`tip-phrase` + `--runtime-tip`）**：提供 X1a0He 风格的短语配置入口，支持 `{from}` 占位符和本地预览。`tip-phrase` 写入当前登录用户的 WeChat 容器偏好文件，请用普通用户执行，不要用 `sudo`。`--runtime-tip` 会把运行时 dylib 安装到 `Contents/Resources`，并给 `wechat.dylib` 注入 `LC_LOAD_DYLIB`，让撤回提示改用配置短语；目前支持构建号 `268597` / `268599`。
 
-**无限多开（`--multi-instance`）**：绕过微信 4.1.9 进程互斥检查，允许同时启动多个客户端实例（当前支持 `268575` / `268599`）。
+**分身多开（`clone` / `split`，推荐）**：复制现有 `WeChat.app`，重写主 app、`WeChatAppEx.app`、`appex`、`xpc` 等嵌套 bundle 的 `CFBundleIdentifier`，然后重签名，生成 `WeChat 2.app` / `WeChat 3.app` 这类独立分身。启动时直接打开分身 app，不再依赖 `open -n /Applications/WeChat.app`。
 
-<u>使用方法：选择带有多开参数的命令安装后，使用命令 `open -n /Applications/WeChat.app` 或者 使用多开启动器： [WeChatMulti](https://github.com/loohalh/WeChatMulti)</u>
-
+**无限多开（`--multi-instance`，旧方案）**：绕过微信 4.1.9 进程互斥检查，允许同时启动多个客户端实例（当前支持 `268575` / `268599`）。该方案在部分 4.1.9 构建上可能触发重复权限弹窗，当前更推荐使用 `clone` 分身方案。
 
 **屏蔽自动更新（`--block-update` / `--update-only`）**：针对微信 4.1.9 的 `XAppUpdateManager`，屏蔽 `startUpdater`、`startBackgroundUpdatesCheck:`、`checkForUpdates:`、`enableAutoUpdate:` 等入口，并让 `automaticallyDownloadsUpdates`、`canCheckForUpdate` 返回 `false`。
 
@@ -52,17 +52,11 @@ swift run wechat-antirecall install --dry-run --app /Applications/WeChat.app
 # 提示模式
 swift run wechat-antirecall install --with-tip --dry-run --app /Applications/WeChat.app
 
-# 提示模式 + 多开
-swift run wechat-antirecall install --with-tip --multi-instance --dry-run --app /Applications/WeChat.app
-
 # 只屏蔽自动更新
 swift run wechat-antirecall install --update-only --dry-run --app /Applications/WeChat.app
 
 # 防撤回并屏蔽自动更新
 swift run wechat-antirecall install --with-tip --block-update --dry-run --app /Applications/WeChat.app
-
-# 防撤回+屏蔽自动更新+多开
-swift run wechat-antirecall install --with-tip --block-update --multi-instance --dry-run --app /Applications/WeChat.app
 ```
 
 **可选步骤**：配置自定义撤回提示短语。
@@ -123,15 +117,34 @@ sudo .build/release/wechat-antirecall install --with-tip --app /Applications/WeC
 # 自定义撤回提示短语（仅 268597 / 268599）
 sudo .build/release/wechat-antirecall install --runtime-tip --app /Applications/WeChat.app
 
-# 提示模式 + 多开
-sudo .build/release/wechat-antirecall install --with-tip --multi-instance --app /Applications/WeChat.app
-
 # 只屏蔽自动更新
 sudo .build/release/wechat-antirecall install --update-only --app /Applications/WeChat.app
-
-# 提示模式防撤回 + 屏蔽自动更新 + 多开
-sudo .build/release/wechat-antirecall install --with-tip --block-update --multi-instance --app /Applications/WeChat.app
 ```
+
+### 分身多开（推荐）
+
+`clone` / `split` 不依赖 `patches.json` 的地址命中，也不需要对同一个 `WeChat.app` 做 `open -n`。它会复制源 app，重写分身里的 bundle 标识并重新签名，适合在已安装好防撤回的源微信上继续生成 `WeChat 2.app`。
+
+请先完全退出源微信，再执行：
+
+```bash
+# 生成 /Applications/WeChat 2.app
+sudo .build/release/wechat-antirecall clone --app /Applications/WeChat.app --index 2
+
+# 生成 /Applications/WeChat 3.app
+sudo .build/release/wechat-antirecall clone --app /Applications/WeChat.app --index 3
+
+# 自定义输出路径
+sudo .build/release/wechat-antirecall clone --app /Applications/WeChat.app --output "/Applications/WeChat Work.app" --index 2
+```
+
+生成后直接打开分身 app：
+
+```bash
+open "/Applications/WeChat 2.app"
+```
+
+如果源微信已经安装了防撤回或 `--runtime-tip`，分身会继承这些修改；如果你希望分身完全干净，请先恢复源微信再执行 `clone`。
 
 如果看到类似：
 
@@ -165,7 +178,6 @@ wechat.dylib.wechat-antirecall-backup-20260505-143000
 sudo .build/release/wechat-antirecall install --app /Applications/WeChat.app --no-backup
 sudo .build/release/wechat-antirecall install --with-tip --app /Applications/WeChat.app --no-backup
 sudo .build/release/wechat-antirecall install --runtime-tip --app /Applications/WeChat.app --no-backup
-sudo .build/release/wechat-antirecall install --with-tip --multi-instance --app /Applications/WeChat.app --no-backup
 sudo .build/release/wechat-antirecall install --update-only --app /Applications/WeChat.app --no-backup
 ```
 
@@ -214,7 +226,7 @@ sudo .build/release/wechat-antirecall restore \
 
 `expected` 支持单个十六进制字符串或字符串数组；提示模式会同时接受"原始字节"和"已装过静默补丁的字节"，支持直接在两种模式间切换而无需先恢复备份。
 
-`multiInstance` 目标目前覆盖 `268575` / `268599`（微信 4.1.9），当前提供 arm64 地址（主二进制 `Contents/MacOS/WeChat`）。
+`multiInstance` 目标目前覆盖 `268575` / `268599`（微信 4.1.9），当前提供 arm64 地址（主二进制 `Contents/MacOS/WeChat`）。`clone` / `split` 分身多开不依赖 `patches.json` 的地址配置，而是复制 app 并重写 bundle 标识。
 
 `update` 目标目前覆盖 `268575` / `268596` / `268597` / `268599`（微信 4.1.9 arm64），核心是让更新入口提前返回，并把更新权限相关 getter 固定为 `false`。
 

--- a/Sources/WeChatAntiRecall/main.swift
+++ b/Sources/WeChatAntiRecall/main.swift
@@ -10,6 +10,7 @@ private let fatMagic: UInt32 = 0xcafebabe
 private let fatMagic64: UInt32 = 0xcafebabf
 private let cpuTypeX8664: Int32 = 0x01000007
 private let cpuTypeARM64: Int32 = 0x0100000c
+private let codesignPreservedMetadata = "entitlements,requirements,flags,runtime"
 
 enum ToolError: LocalizedError {
     case usage(String)
@@ -480,6 +481,8 @@ struct CLI {
             try install(rest)
         case "restore":
             try restore(rest)
+        case "clone", "split":
+            try clone(rest)
         case "tip-phrase":
             try tipPhrase(rest)
         case "help", "--help", "-h":
@@ -727,6 +730,59 @@ struct CLI {
         }
     }
 
+    private func clone(_ arguments: [String]) throws {
+        let options = try CloneOptions(arguments)
+        let sourceAppInfo = try readAppInfo(appPath: options.appPath)
+        let outputURL = options.outputURL(for: sourceAppInfo.appURL).standardizedFileURL
+        let sourceURL = sourceAppInfo.appURL.standardizedFileURL
+
+        guard sourceURL != outputURL else {
+            throw ToolError.usage("clone 输出路径不能与源应用相同")
+        }
+        guard !FileManager.default.fileExists(atPath: outputURL.path) else {
+            throw ToolError.usage("clone 输出路径已存在：\(outputURL.path)")
+        }
+
+        print("Source: \(sourceAppInfo.appURL.path)")
+        print("Output: \(outputURL.path)")
+        print("Clone token: \(options.cloneToken)")
+        print("Checking whether source WeChat is running...")
+        try ensureAppNotRunning(appInfo: sourceAppInfo, dryRun: false)
+        print("Checking clone permissions...")
+        try validateClonePermissions(outputURL: outputURL)
+        print("Copying WeChat.app...")
+        do {
+            try FileManager.default.copyItem(at: sourceAppInfo.appURL, to: outputURL)
+        } catch {
+            throw ToolError.fileOperationFailed(
+                operation: "复制 WeChat.app",
+                path: outputURL.path,
+                underlying: error.localizedDescription
+            )
+        }
+
+        let changes = try AppCloneRewriter(
+            appURL: outputURL,
+            sourceMainBundleIdentifier: sourceAppInfo.bundleIdentifier,
+            cloneToken: options.cloneToken
+        ).rewrite()
+
+        print("Updated bundle identifiers:")
+        for change in changes {
+            print("  - \(change.relativePlistPath): \(change.oldIdentifier) -> \(change.newIdentifier)")
+        }
+
+        if options.skipResign {
+            print("Skipped code signing.")
+        } else {
+            print("Re-signing cloned app...")
+            try resign(appURL: outputURL, nestedBinaries: [])
+            print("Code signing complete.")
+        }
+
+        print("Clone created: \(outputURL.path)")
+    }
+
     private func printUsage() {
         print("""
         wechat-antirecall
@@ -735,6 +791,7 @@ struct CLI {
           wechat-antirecall versions [--app /Applications/WeChat.app] [--config patches.json]
           wechat-antirecall install  [--app /Applications/WeChat.app] [--config patches.json] [--with-tip] [--runtime-tip] [--runtime-dylib <path>] [--multi-instance] [--block-update] [--update-only] [--dry-run] [--no-backup] [--skip-resign]
           wechat-antirecall restore  --backup <path> [--binary Contents/MacOS/WeChat] [--app /Applications/WeChat.app] [--skip-resign]
+          wechat-antirecall clone    [--app /Applications/WeChat.app] [--output /Applications/WeChat 2.app] [--index 2] [--skip-resign]
           wechat-antirecall tip-phrase get
           wechat-antirecall tip-phrase set <phrase>
           wechat-antirecall tip-phrase reset
@@ -872,6 +929,51 @@ private func displayName(forTargetIdentifier identifier: String) -> String {
         return "enable multi-instance (extra)"
     default:
         return identifier
+    }
+}
+
+struct CloneOptions {
+    var appPath = defaultAppPath
+    var outputPath: String?
+    var index = 2
+    var skipResign = false
+
+    var cloneToken: String {
+        "clone\(index)"
+    }
+
+    init(_ arguments: [String]) throws {
+        var parser = ArgumentCursor(arguments)
+        while let argument = parser.next() {
+            switch argument {
+            case "--app":
+                appPath = try parser.requiredValue(after: argument)
+            case "--output":
+                outputPath = try parser.requiredValue(after: argument)
+            case "--index":
+                let value = try parser.requiredValue(after: argument)
+                guard let parsed = Int(value), parsed >= 2 else {
+                    throw ToolError.usage("--index 需要一个大于等于 2 的整数")
+                }
+                index = parsed
+            case "--skip-resign":
+                skipResign = true
+            default:
+                throw ToolError.usage("未知参数：\(argument)")
+            }
+        }
+    }
+
+    func outputURL(for sourceAppURL: URL) -> URL {
+        if let outputPath {
+            let url = URL(fileURLWithPath: outputPath)
+            return url.pathExtension.lowercased() == "app" ? url : url.appendingPathExtension("app")
+        }
+
+        let sourceName = sourceAppURL.deletingPathExtension().lastPathComponent
+        return sourceAppURL
+            .deletingLastPathComponent()
+            .appendingPathComponent("\(sourceName) \(index).app")
     }
 }
 
@@ -1447,7 +1549,7 @@ private func readAppInfo(appPath: String) throws -> AppInfo {
     guard let bundleIdentifier = plist["CFBundleIdentifier"] as? String else {
         throw ToolError.appInfoMissing("CFBundleIdentifier")
     }
-    guard bundleIdentifier == "com.tencent.xinWeChat" || bundleIdentifier == "com.tencent.xin" else {
+    guard isSupportedWechatBundleIdentifier(bundleIdentifier) else {
         throw ToolError.notAWechatApp(appPath)
     }
 
@@ -1458,6 +1560,128 @@ private func readAppInfo(appPath: String) throws -> AppInfo {
         buildVersion: buildVersion,
         bundleIdentifier: bundleIdentifier
     )
+}
+
+struct BundleIdentifierChange: Equatable {
+    let relativePlistPath: String
+    let oldIdentifier: String
+    let newIdentifier: String
+}
+
+struct AppCloneRewriter {
+    let appURL: URL
+    let sourceMainBundleIdentifier: String
+    let cloneToken: String
+
+    func rewrite() throws -> [BundleIdentifierChange] {
+        var changes: [BundleIdentifierChange] = []
+        for plistURL in try Self.bundleInfoPlistURLs(in: appURL) {
+            var (plist, format) = try readPropertyListDictionary(at: plistURL)
+            guard let currentIdentifier = plist["CFBundleIdentifier"] as? String,
+                  let clonedIdentifier = Self.clonedBundleIdentifier(
+                    from: currentIdentifier,
+                    sourceMainBundleIdentifier: sourceMainBundleIdentifier,
+                    cloneToken: cloneToken
+                  ),
+                  clonedIdentifier != currentIdentifier else {
+                continue
+            }
+
+            plist["CFBundleIdentifier"] = clonedIdentifier
+            try writePropertyListDictionary(plist, format: format, to: plistURL)
+            let relativePath = plistURL.path.replacingOccurrences(of: appURL.path + "/", with: "")
+            changes.append(BundleIdentifierChange(
+                relativePlistPath: relativePath,
+                oldIdentifier: currentIdentifier,
+                newIdentifier: clonedIdentifier
+            ))
+        }
+        return changes
+    }
+
+    static func bundleInfoPlistURLs(in appURL: URL) throws -> [URL] {
+        guard let enumerator = FileManager.default.enumerator(
+            at: appURL,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return []
+        }
+
+        var urls: [URL] = []
+        for case let url as URL in enumerator {
+            guard url.lastPathComponent == "Info.plist", url.path.hasSuffix("/Contents/Info.plist") else {
+                continue
+            }
+            urls.append(url)
+        }
+        return urls.sorted { $0.path < $1.path }
+    }
+
+    static func clonedBundleIdentifier(
+        from original: String,
+        sourceMainBundleIdentifier: String,
+        cloneToken: String
+    ) -> String? {
+        var roots = [sourceMainBundleIdentifier, "com.tencent.xinWeChat", "com.tencent.xin", "com.tencent.flue", "com.tencent.xWechat"]
+        roots = roots.reduce(into: []) { result, root in
+            if !result.contains(root) {
+                result.append(root)
+            }
+        }
+
+        for root in roots {
+            if original == root {
+                return "\(root).\(cloneToken)"
+            }
+
+            let prefix = "\(root)."
+            if original.hasPrefix(prefix) {
+                return "\(root).\(cloneToken).\(original.dropFirst(prefix.count))"
+            }
+        }
+
+        return nil
+    }
+}
+
+private func isSupportedWechatBundleIdentifier(_ bundleIdentifier: String) -> Bool {
+    let supportedRoots = ["com.tencent.xinWeChat", "com.tencent.xin"]
+    return supportedRoots.contains(bundleIdentifier) || supportedRoots.contains { bundleIdentifier.hasPrefix("\($0).") }
+}
+
+private func validateClonePermissions(outputURL: URL) throws {
+    try requireDirectoryWritable(outputURL.deletingLastPathComponent(), operation: "创建 WeChat 分身")
+}
+
+private func readPropertyListDictionary(at url: URL) throws -> ([String: Any], PropertyListSerialization.PropertyListFormat) {
+    let data = try Data(contentsOf: url)
+    var format = PropertyListSerialization.PropertyListFormat.binary
+    guard let plist = try PropertyListSerialization.propertyList(from: data, options: [], format: &format) as? [String: Any] else {
+        throw ToolError.fileOperationFailed(
+            operation: "读取 Info.plist",
+            path: url.path,
+            underlying: "顶层对象不是字典"
+        )
+    }
+    return (plist, format)
+}
+
+private func writePropertyListDictionary(
+    _ plist: [String: Any],
+    format: PropertyListSerialization.PropertyListFormat,
+    to url: URL
+) throws {
+    do {
+        let data = try PropertyListSerialization.data(fromPropertyList: plist, format: format, options: 0)
+        try data.write(to: url, options: .atomic)
+    } catch {
+        throw ToolError.fileOperationFailed(
+            operation: "写入 Info.plist",
+            path: url.path,
+            underlying: error.localizedDescription
+        )
+    }
 }
 
 private func configForInstalledApp(_ appInfo: AppInfo, configs: [VersionConfig]) throws -> VersionConfig {
@@ -1602,15 +1826,17 @@ private func resign(appURL: URL, nestedBinaries: [URL]) throws {
         try signMachO(at: binaryURL)
     }
 
-    try runProcess("/usr/bin/codesign", ["--remove-sign", appURL.path])
-    try runProcess("/usr/bin/codesign", ["--force", "--deep", "--sign", "-", appURL.path])
+    _ = runProcessStatus("/usr/bin/codesign", ["--remove-sign", appURL.path])
+    try runCodesign(at: appURL.path, deep: true)
     try runProcess("/usr/bin/xattr", ["-cr", appURL.path])
 }
 
 private func signMachO(at url: URL) throws {
     _ = runProcessStatus("/usr/bin/codesign", ["--remove-sign", url.path])
-    if runProcessStatus("/usr/bin/codesign", ["--force", "--sign", "-", url.path]) == 0 {
+    do {
+        try runCodesign(at: url.path, deep: false)
         return
+    } catch {
     }
 
     try signMachOUsingTemporaryCopy(at: url)
@@ -1627,8 +1853,18 @@ private func signMachOUsingTemporaryCopy(at url: URL) throws {
     let temporaryURL = temporaryDirectory.appendingPathComponent(url.lastPathComponent)
     try FileManager.default.copyItem(at: url, to: temporaryURL)
     _ = runProcessStatus("/usr/bin/codesign", ["--remove-sign", temporaryURL.path])
-    try runProcess("/usr/bin/codesign", ["--force", "--sign", "-", temporaryURL.path])
+    try runCodesign(at: temporaryURL.path, deep: false)
     try runProcess("/bin/cp", ["-p", temporaryURL.path, url.path])
+}
+
+private func runCodesign(at path: String, deep: Bool) throws {
+    let baseArguments = ["--force"] + (deep ? ["--deep"] : [])
+    let preservedArguments = baseArguments + ["--preserve-metadata=\(codesignPreservedMetadata)", "--sign", "-", path]
+    if runProcessStatus("/usr/bin/codesign", preservedArguments) == 0 {
+        return
+    }
+
+    try runProcess("/usr/bin/codesign", baseArguments + ["--sign", "-", path])
 }
 
 private func uniqueURLs(_ urls: [URL]) -> [URL] {

--- a/Sources/WeChatAntiRecall/main.swift
+++ b/Sources/WeChatAntiRecall/main.swift
@@ -1304,7 +1304,7 @@ struct RuntimeTipInstaller {
     static let installName = "@loader_path/\(dylibFileName)"
     static let hostBinaryPath = "Contents/Resources/wechat.dylib"
     static let destinationDylibPath = "Contents/Resources/\(dylibFileName)"
-    static let supportedBuildVersion = "268597"
+    static let supportedBuildVersions = ["268597", "268599"]
 
     let sourceDylibURL: URL
     let destinationDylibURL: URL
@@ -1318,9 +1318,9 @@ struct RuntimeTipInstaller {
         guard options.runtimeTip else {
             throw ToolError.invalidConfig("runtime-tip 未启用")
         }
-        guard appInfo.buildVersion == Self.supportedBuildVersion else {
+        guard Self.supportedBuildVersions.contains(appInfo.buildVersion) else {
             throw ToolError.invalidConfig(
-                "runtime-tip 目前只支持微信构建号 \(Self.supportedBuildVersion)，当前构建号是 \(appInfo.buildVersion)"
+                "runtime-tip 目前只支持微信构建号 \(Self.supportedBuildVersions.joined(separator: ", "))，当前构建号是 \(appInfo.buildVersion)"
             )
         }
 

--- a/Sources/WeChatAntiRecallRuntime/Runtime.mm
+++ b/Sources/WeChatAntiRecallRuntime/Runtime.mm
@@ -15,18 +15,137 @@
 
 namespace {
 
-constexpr uintptr_t parseRevokeXMLHookSlot = 0x92da2c0;
-constexpr uintptr_t parseRevokeXMLOriginalBody = 0x4764540;
-constexpr ptrdiff_t revokeNewMsgIdOffset = 0x168;
-constexpr ptrdiff_t revokeReplaceMsgOffset = 0x170;
 constexpr NSUInteger revokeTipMaximumLength = 120;
 constexpr size_t revokeTimeCacheMaximumCount = 512;
+
+struct RevokeHookConfig {
+    const char *buildVersion;
+    uintptr_t parseRevokeXMLOriginalBody;
+    ptrdiff_t revokeNewMsgIdOffset;
+    ptrdiff_t revokeReplaceMsgOffset;
+};
+
+constexpr RevokeHookConfig revokeHookConfigs[] = {
+    {"268597", 0x4764540, 0x168, 0x170},
+    {"268599", 0x47775cc, 0x168, 0x170},
+};
 
 using ParseRevokeXML = bool (*)(void *, std::string *, void *, uint32_t);
 
 ParseRevokeXML originalParseRevokeXML = nullptr;
 std::mutex revokeTimeCacheMutex;
 std::unordered_map<std::string, std::string> revokeTimeCache;
+
+NSString *mainBundleBuildVersion() {
+    @autoreleasepool {
+        id value = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"];
+        return [value isKindOfClass:[NSString class]] ? static_cast<NSString *>(value) : nil;
+    }
+}
+
+const RevokeHookConfig *revokeHookConfigForBuildVersion(NSString *buildVersion) {
+    if (buildVersion == nil) {
+        return nullptr;
+    }
+
+    const char *utf8 = [buildVersion UTF8String];
+    if (utf8 == nullptr) {
+        return nullptr;
+    }
+
+    for (const auto &config : revokeHookConfigs) {
+        if (std::strcmp(config.buildVersion, utf8) == 0) {
+            return &config;
+        }
+    }
+
+    return nullptr;
+}
+
+const RevokeHookConfig *currentRevokeHookConfig() {
+    return revokeHookConfigForBuildVersion(mainBundleBuildVersion());
+}
+
+bool decodeADRPPage(uint32_t instruction, uintptr_t instructionAddress, uintptr_t &pageAddress) {
+    if ((instruction & 0x9F000000) != 0x90000000) {
+        return false;
+    }
+
+    int64_t imm = static_cast<int64_t>(((instruction >> 5) & 0x7ffff) << 2 | ((instruction >> 29) & 0x3));
+    if ((imm & (1 << 20)) != 0) {
+        imm -= (1 << 21);
+    }
+
+    pageAddress = (instructionAddress & ~static_cast<uintptr_t>(0xfff)) + (static_cast<uintptr_t>(imm) << 12);
+    return true;
+}
+
+bool decodeLDRUnsignedImmediate64(uint32_t instruction, uint32_t &targetRegister, uint32_t &baseRegister, uintptr_t &offset) {
+    if ((instruction & 0xFFC00000) != 0xF9400000) {
+        return false;
+    }
+
+    targetRegister = instruction & 0x1f;
+    baseRegister = (instruction >> 5) & 0x1f;
+    offset = static_cast<uintptr_t>((instruction >> 10) & 0xfff) << 3;
+    return true;
+}
+
+bool decodeCBZTarget64(uint32_t instruction, uintptr_t instructionAddress, uint32_t &targetRegister, uintptr_t &targetAddress) {
+    if ((instruction & 0xFF000000) != 0xB4000000) {
+        return false;
+    }
+
+    int64_t imm = static_cast<int64_t>((instruction >> 5) & 0x7ffff);
+    if ((imm & (1 << 18)) != 0) {
+        imm -= (1 << 19);
+    }
+
+    targetRegister = instruction & 0x1f;
+    targetAddress = instructionAddress + static_cast<uintptr_t>(imm << 2);
+    return true;
+}
+
+bool isBranchRegister(uint32_t instruction, uint32_t targetRegister) {
+    return instruction == (0xD61F0000 | (targetRegister << 5));
+}
+
+uintptr_t resolveParseRevokeXMLHookSlot(uintptr_t originalBodyAddress) {
+    if (originalBodyAddress < 16) {
+        return 0;
+    }
+
+    const uintptr_t stubAddress = originalBodyAddress - 16;
+    const auto *instructions = reinterpret_cast<const uint32_t *>(stubAddress);
+
+    uintptr_t pageAddress = 0;
+    if (!decodeADRPPage(instructions[0], stubAddress, pageAddress)) {
+        return 0;
+    }
+
+    uint32_t ldrTargetRegister = 0;
+    uint32_t ldrBaseRegister = 0;
+    uintptr_t ldrOffset = 0;
+    if (!decodeLDRUnsignedImmediate64(instructions[1], ldrTargetRegister, ldrBaseRegister, ldrOffset)) {
+        return 0;
+    }
+
+    uintptr_t cbzTarget = 0;
+    uint32_t cbzRegister = 0;
+    if (!decodeCBZTarget64(instructions[2], stubAddress + 8, cbzRegister, cbzTarget)) {
+        return 0;
+    }
+
+    if (ldrTargetRegister != ldrBaseRegister || cbzRegister != ldrTargetRegister || cbzTarget != originalBodyAddress) {
+        return 0;
+    }
+
+    if (!isBranchRegister(instructions[3], ldrTargetRegister)) {
+        return 0;
+    }
+
+    return pageAddress + ldrOffset;
+}
 
 std::string trimCopy(const std::string &value) {
     const char *whitespace = " \t\r\n\"'";
@@ -551,13 +670,18 @@ bool hookedParseRevokeXML(void *message, std::string *xml, void *flag, uint32_t 
         return false;
     }
 
+    const auto *hookConfig = currentRevokeHookConfig();
+    if (hookConfig == nullptr) {
+        return false;
+    }
+
     const bool result = originalParseRevokeXML(message, xml, flag, msgType);
     if (!result || message == nullptr) {
         return result;
     }
 
-    auto *newMsgId = reinterpret_cast<uint64_t *>(reinterpret_cast<uint8_t *>(message) + revokeNewMsgIdOffset);
-    auto *replaceMsg = reinterpret_cast<std::string *>(reinterpret_cast<uint8_t *>(message) + revokeReplaceMsgOffset);
+    auto *newMsgId = reinterpret_cast<uint64_t *>(reinterpret_cast<uint8_t *>(message) + hookConfig->revokeNewMsgIdOffset);
+    auto *replaceMsg = reinterpret_cast<std::string *>(reinterpret_cast<uint8_t *>(message) + hookConfig->revokeReplaceMsgOffset);
     const uint64_t originalNewMsgId = *newMsgId;
     const std::string originalReplaceMsg = *replaceMsg;
 
@@ -614,17 +738,28 @@ bool writeHookSlot(void **slot, void *replacement) {
 }
 
 void installRevokeTipHook() {
+    const auto *hookConfig = currentRevokeHookConfig();
+    if (hookConfig == nullptr) {
+        return;
+    }
+
     const uintptr_t slide = findWeChatDylibSlide();
     if (slide == 0) {
         return;
     }
 
-    auto **hookSlot = reinterpret_cast<void **>(slide + parseRevokeXMLHookSlot);
+    const uintptr_t originalBodyAddress = slide + hookConfig->parseRevokeXMLOriginalBody;
+    const uintptr_t hookSlotAddress = resolveParseRevokeXMLHookSlot(originalBodyAddress);
+    if (hookSlotAddress == 0) {
+        return;
+    }
+
+    auto **hookSlot = reinterpret_cast<void **>(hookSlotAddress);
     if (*hookSlot == reinterpret_cast<void *>(&hookedParseRevokeXML)) {
         return;
     }
 
-    originalParseRevokeXML = reinterpret_cast<ParseRevokeXML>(slide + parseRevokeXMLOriginalBody);
+    originalParseRevokeXML = reinterpret_cast<ParseRevokeXML>(originalBodyAddress);
     writeHookSlot(hookSlot, reinterpret_cast<void *>(&hookedParseRevokeXML));
 }
 

--- a/Tests/WeChatAntiRecallTests/MachODylibInjectorTests.swift
+++ b/Tests/WeChatAntiRecallTests/MachODylibInjectorTests.swift
@@ -300,3 +300,112 @@ private extension Data {
         }
     }
 }
+
+
+final class CloneWorkflowTests: XCTestCase {
+    func testCloneOptionsDerivesDefaultOutputAndToken() throws {
+        let options = try CloneOptions(["--index", "3"])
+
+        XCTAssertEqual(options.cloneToken, "clone3")
+        XCTAssertEqual(
+            options.outputURL(for: URL(fileURLWithPath: "/Applications/WeChat.app")).path,
+            "/Applications/WeChat 3.app"
+        )
+    }
+
+    func testCloneOptionsAppendsAppExtensionToCustomOutput() throws {
+        let options = try CloneOptions(["--output", "/tmp/WeChat-Work"])
+
+        XCTAssertEqual(
+            options.outputURL(for: URL(fileURLWithPath: "/Applications/WeChat.app")).path,
+            "/tmp/WeChat-Work.app"
+        )
+    }
+
+    func testAppCloneRewriterRewritesBundlesForAppsExtensionsAndXPCs() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wechat-antirecall-clone-\(UUID().uuidString)", isDirectory: true)
+        defer {
+            try? FileManager.default.removeItem(at: directory)
+        }
+
+        let appURL = directory.appendingPathComponent("WeChat 2.app", isDirectory: true)
+        try writePlist([
+            "CFBundleIdentifier": "com.tencent.xinWeChat",
+            "CFBundleExecutable": "WeChat",
+            "CFBundleShortVersionString": "4.1.9",
+            "CFBundleVersion": "268599"
+        ], to: appURL.appendingPathComponent("Contents/Info.plist"))
+        try writePlist(
+            ["CFBundleIdentifier": "com.tencent.flue.WeChatAppEx"],
+            to: appURL.appendingPathComponent("Contents/MacOS/WeChatAppEx.app/Contents/Info.plist")
+        )
+        try writePlist(
+            ["CFBundleIdentifier": "com.tencent.flue.helper"],
+            to: appURL.appendingPathComponent(
+                "Contents/MacOS/WeChatAppEx.app/Contents/Frameworks/WeChatAppEx Framework.framework/Versions/C/Helpers/WeChatAppEx Helper.app/Contents/Info.plist"
+            )
+        )
+        try writePlist(
+            ["CFBundleIdentifier": "com.tencent.xinWeChat.WeChatMacShare"],
+            to: appURL.appendingPathComponent("Contents/PlugIns/WeChatMacShare.appex/Contents/Info.plist")
+        )
+        try writePlist(
+            ["CFBundleIdentifier": "com.tencent.xWechat.DebugHelper"],
+            to: appURL.appendingPathComponent("Contents/XPCServices/DebugHelper.xpc/Contents/Info.plist")
+        )
+        try writePlist(
+            ["CFBundleIdentifier": "org.sparkle-project.Sparkle"],
+            to: appURL.appendingPathComponent("Contents/Frameworks/Sparkle.framework/Versions/B/Resources/Info.plist")
+        )
+
+        let changes = try AppCloneRewriter(
+            appURL: appURL,
+            sourceMainBundleIdentifier: "com.tencent.xinWeChat",
+            cloneToken: "clone2"
+        ).rewrite()
+
+        XCTAssertEqual(changes.count, 5)
+        XCTAssertEqual(
+            try readBundleIdentifier(at: appURL.appendingPathComponent("Contents/Info.plist")),
+            "com.tencent.xinWeChat.clone2"
+        )
+        XCTAssertEqual(
+            try readBundleIdentifier(at: appURL.appendingPathComponent("Contents/MacOS/WeChatAppEx.app/Contents/Info.plist")),
+            "com.tencent.flue.clone2.WeChatAppEx"
+        )
+        XCTAssertEqual(
+            try readBundleIdentifier(at: appURL.appendingPathComponent(
+                "Contents/MacOS/WeChatAppEx.app/Contents/Frameworks/WeChatAppEx Framework.framework/Versions/C/Helpers/WeChatAppEx Helper.app/Contents/Info.plist"
+            )),
+            "com.tencent.flue.clone2.helper"
+        )
+        XCTAssertEqual(
+            try readBundleIdentifier(at: appURL.appendingPathComponent("Contents/PlugIns/WeChatMacShare.appex/Contents/Info.plist")),
+            "com.tencent.xinWeChat.clone2.WeChatMacShare"
+        )
+        XCTAssertEqual(
+            try readBundleIdentifier(at: appURL.appendingPathComponent("Contents/XPCServices/DebugHelper.xpc/Contents/Info.plist")),
+            "com.tencent.xWechat.clone2.DebugHelper"
+        )
+        XCTAssertEqual(
+            try readBundleIdentifier(at: appURL.appendingPathComponent("Contents/Frameworks/Sparkle.framework/Versions/B/Resources/Info.plist")),
+            "org.sparkle-project.Sparkle"
+        )
+    }
+
+    private func writePlist(_ plist: [String: Any], to url: URL) throws {
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let data = try PropertyListSerialization.data(fromPropertyList: plist, format: .binary, options: 0)
+        try data.write(to: url)
+    }
+
+    private func readBundleIdentifier(at url: URL) throws -> String {
+        let data = try Data(contentsOf: url)
+        var format = PropertyListSerialization.PropertyListFormat.binary
+        let plist = try XCTUnwrap(
+            PropertyListSerialization.propertyList(from: data, options: [], format: &format) as? [String: Any]
+        )
+        return try XCTUnwrap(plist["CFBundleIdentifier"] as? String)
+    }
+}

--- a/Tests/WeChatAntiRecallTests/MachODylibInjectorTests.swift
+++ b/Tests/WeChatAntiRecallTests/MachODylibInjectorTests.swift
@@ -106,6 +106,43 @@ final class MachODylibInjectorTests: XCTestCase {
         XCTAssertTrue(try loadDylibCommands(in: hostBinaryURL).contains(RuntimeTipInstaller.installName))
     }
 
+    func testRuntimeInstallerCopiesDylibAndInjectsHostBinaryForBuild268599() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wechat-antirecall-runtime-\(UUID().uuidString)", isDirectory: true)
+        defer {
+            try? FileManager.default.removeItem(at: directory)
+        }
+
+        let resourcesURL = directory
+            .appendingPathComponent("WeChat.app/Contents/Resources", isDirectory: true)
+        try FileManager.default.createDirectory(at: resourcesURL, withIntermediateDirectories: true)
+
+        let hostBinaryURL = resourcesURL.appendingPathComponent("wechat.dylib")
+        try Data(contentsOf: try makeTemporaryMachO()).write(to: hostBinaryURL)
+
+        let sourceDylibURL = directory.appendingPathComponent(RuntimeTipInstaller.dylibFileName)
+        try Data([0xca, 0xfe, 0xba, 0xbe]).write(to: sourceDylibURL)
+
+        let appInfo = AppInfo(
+            appURL: directory.appendingPathComponent("WeChat.app"),
+            executableURL: directory.appendingPathComponent("WeChat.app/Contents/MacOS/WeChat"),
+            shortVersion: "4.1.9",
+            buildVersion: "268599",
+            bundleIdentifier: "com.tencent.xinWeChat"
+        )
+        let options = try InstallOptions(["--runtime-dylib", sourceDylibURL.path])
+
+        let installer = try RuntimeTipInstaller(appInfo: appInfo, options: options)
+        let reports = try installer.install(dryRun: false)
+
+        XCTAssertEqual(reports.map(\.status), [.injected])
+        XCTAssertEqual(
+            try Data(contentsOf: resourcesURL.appendingPathComponent(RuntimeTipInstaller.dylibFileName)),
+            try Data(contentsOf: sourceDylibURL)
+        )
+        XCTAssertTrue(try loadDylibCommands(in: hostBinaryURL).contains(RuntimeTipInstaller.installName))
+    }
+
     func testRuntimeInstallerRejectsUnsupportedBuildVersion() throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("wechat-antirecall-runtime-\(UUID().uuidString)", isDirectory: true)
@@ -129,7 +166,7 @@ final class MachODylibInjectorTests: XCTestCase {
         XCTAssertThrowsError(try RuntimeTipInstaller(appInfo: appInfo, options: options)) { error in
             XCTAssertEqual(
                 error.localizedDescription,
-                "补丁配置无效：runtime-tip 目前只支持微信构建号 268597，当前构建号是 268596"
+                "补丁配置无效：runtime-tip 目前只支持微信构建号 268597, 268599，当前构建号是 268596"
             )
         }
     }

--- a/patches.json
+++ b/patches.json
@@ -463,5 +463,153 @@
         ]
       }
     ]
+  },
+  {
+    "version": "268599",
+    "targets": [
+      {
+        "identifier": "revoke",
+        "binary": "Contents/Resources/wechat.dylib",
+        "entries": [
+          {
+            "arch": "arm64",
+            "addr": "477783c",
+            "expected": "E00F0034",
+            "asm": "7F000014"
+          }
+        ]
+      },
+      {
+        "identifier": "revoke-tip",
+        "binary": "Contents/Resources/wechat.dylib",
+        "entries": [
+          {
+            "arch": "arm64",
+            "addr": "477783c",
+            "expected": [
+              "E00F0034",
+              "7F000014"
+            ],
+            "asm": "E00F0034"
+          },
+          {
+            "arch": "arm64",
+            "addr": "4777fd0",
+            "expected": "60B600F9",
+            "asm": "7FB600F9"
+          }
+        ]
+      },
+      {
+        "identifier": "update",
+        "binary": "Contents/Resources/wechat.dylib",
+        "entries": [
+          {
+            "arch": "arm64",
+            "addr": "1c6f2c",
+            "expected": "FC6FBBA9",
+            "asm": "C0035FD6"
+          },
+          {
+            "arch": "arm64",
+            "addr": "1c9148",
+            "expected": "FFC305D1",
+            "asm": "C0035FD6"
+          },
+          {
+            "arch": "arm64",
+            "addr": "1c9418",
+            "expected": "FF4301D1",
+            "asm": "C0035FD6"
+          },
+          {
+            "arch": "arm64",
+            "addr": "1c9840",
+            "expected": "F657BDA9",
+            "asm": "C0035FD6"
+          },
+          {
+            "arch": "arm64",
+            "addr": "1cb9ec",
+            "expected": "FFC305D1",
+            "asm": "C0035FD6"
+          },
+          {
+            "arch": "arm64",
+            "addr": "1d0514",
+            "expected": "00604039C0035FD6",
+            "asm": "00008052C0035FD6"
+          },
+          {
+            "arch": "arm64",
+            "addr": "1d051c",
+            "expected": "02600039",
+            "asm": "C0035FD6"
+          },
+          {
+            "arch": "arm64",
+            "addr": "1d0524",
+            "expected": "00644039C0035FD6",
+            "asm": "00008052C0035FD6"
+          },
+          {
+            "arch": "arm64",
+            "addr": "1d052c",
+            "expected": "02640039",
+            "asm": "C0035FD6"
+          }
+        ]
+      },
+      {
+        "identifier": "multiInstance",
+        "entries": [
+          {
+            "arch": "arm64",
+            "addr": "10001f784",
+            "expected": [
+              "FF8306D1F65717A9",
+              "00008052C0035FD6"
+            ],
+            "asm": "00008052C0035FD6"
+          },
+          {
+            "arch": "arm64",
+            "addr": "100026a78",
+            "expected": [
+              "13008012",
+              "13008052"
+            ],
+            "asm": "13008052"
+          },
+          {
+            "arch": "arm64",
+            "addr": "1000271d0",
+            "expected": [
+              "13008012",
+              "13008052"
+            ],
+            "asm": "13008052"
+          },
+          {
+            "arch": "arm64",
+            "addr": "100026c38",
+            "expected": [
+              "F30300AA",
+              "F3031FAA"
+            ],
+            "asm": "F3031FAA"
+          },
+          {
+            "arch": "arm64",
+            "addr": "100026c3c",
+            "expected": [
+              "80160034",
+              "B4000014"
+            ],
+            "asm": "B4000014"
+          }
+        ]
+      }
+    ]
   }
 ]


### PR DESCRIPTION
  ## 概述

  主要围绕微信 4.1.9 的兼容性、自定义撤回提示运行时、分身多开方案以及文档/构建流程整理展开。

  ## 主要变更

  ### 1. 补充微信 4.1.9.55（268599）支持
  - 新增 `268599` 的补丁配置支持
  - 覆盖能力包括：
    - 静默防撤回
    - 提示模式防撤回
    - 屏蔽自动更新
    - 旧式 `multiInstance`
    - `--runtime-tip` 自定义撤回提示运行时

  ### 2. 优化自定义撤回提示运行时
  - 修复自定义撤回提示短语处理问题
  - 修复重复撤回提示渲染问题
  - 优化时间占位符渲染：
    - 折叠重复时间标记
    - 对同一条已渲染撤回提示保留原时间信息
  - 补充对应运行时测试

  ### 3. 新增 `clone` / `split` 分身多开方案
  - 新增 `clone` / `split` 命令
  - 支持复制现有 `WeChat.app` 并生成独立分身，如：
    - `WeChat 2.app`
    - `WeChat 3.app`
  - 自动重写主 app 及嵌套 bundle 的 `CFBundleIdentifier`，包括：
    - `WeChatAppEx.app`
    - `appex`
    - `xpc`
    - helper / nested app
  - 自动重签名分身 app
  - 在复制前增加源微信运行状态检查
  - 将该方案作为推荐的多开路径，替代依赖 `open -n` 的旧方案

  ### 4. 调整构建配置
  - 在 `Package.swift` 中启用 `C++17`
  - 解决 `WeChatAntiRecallRuntime` 中 ObjC++ / C++17 语法的编译问题

  ### 5. 更新 README
  - 重写安装说明与故障排查内容
  - 补充分身多开推荐流程
  - 明确：
    - 标准安装步骤
    - runtime-tip 使用方式
    - 签名验证方法
    - 备份恢复方式
    - 旧式 `multiInstance` 与推荐分身方案的区别

  ## 说明

  - 旧的 `--multi-instance` 方案仍然保留，用于兼容已有补丁路径
  - 新增的 `clone/split` 分身方案不依赖 `patches.json` 中的多开地址配置，稳定性更高，更适合作为主路径
  - 如果源微信已经安装了防撤回或 `--runtime-tip`，分身会继承这些修改

  ## 验证

  已完成：
  - `swift test`
  - `swift build -c release`

  并补充了分身多开相关测试，覆盖：
  - `clone` 参数解析
  - 分身 bundle identifier 重写逻辑