### PR TITLE
fix(resign): inject hardened-runtime entitlements so 4.1.12 launches & logs in

### DIFF
--- a/Sources/WeChatAntiRecall/CLI.swift
+++ b/Sources/WeChatAntiRecall/CLI.swift
@@ -1766,6 +1766,43 @@ private func makeBackup(of fileURL: URL) throws -> URL {
     return backupURL
 }
 
+/// Ad-hoc re-signing preserves Hardened Runtime (`--preserve-metadata=...,runtime`) and the
+/// original entitlements, which is correct in principle but breaks the app in two ways under an
+/// ad-hoc identity:
+///
+/// 1. WeChat's entitlements carry Tencent's Team ID via `com.apple.application-identifier`
+///    (5A4RE8SF68…), so AMFI treats the re-signed main binary as belonging to that Team ID,
+///    while the re-signed frameworks are Team-less ad-hoc. Launching then aborts with "mapping
+///    process and mapped file (non-platform) have different Team IDs" the moment the main binary
+///    loads one of its own frameworks (e.g. WCDYWrapper.framework). Disabling library validation
+///    fixes this.
+/// 2. At login, `wechat.dylib` jumps into anonymously mapped RX memory (runtime-generated code
+///    next to roam_server.framework's `__LINKEDIT`). Hardened Runtime rejects unsigned anonymous
+///    executable pages with `Invalid Page` (SIGKILL, Namespace CODESIGNING). The original
+///    Developer-ID build runs this via `allow-jit`, but that only covers `MAP_JIT` mappings;
+///    `allow-unsigned-executable-memory` additionally covers plain mmap'd RX trampolines, which
+///    the Tencent code path uses under the re-signed identity.
+///
+/// Both entitlements are injected on every component that already carries entitlements. Returns
+/// the input unchanged when there are no entitlements or the plist cannot be parsed.
+private func injectDisableLibraryValidation(_ entitlements: Data?) -> Data? {
+    guard let entitlements else { return nil }
+    guard var dictionary = try? PropertyListSerialization.propertyList(
+        from: entitlements,
+        options: [],
+        format: nil
+    ) as? [String: Any] else {
+        return entitlements
+    }
+    dictionary["com.apple.security.cs.disable-library-validation"] = true
+    dictionary["com.apple.security.cs.allow-unsigned-executable-memory"] = true
+    return (try? PropertyListSerialization.data(
+        fromPropertyList: dictionary,
+        format: .xml,
+        options: 0
+    )) ?? entitlements
+}
+
 struct CodeSigningEntitlementsSnapshot {
     struct Entry {
         let url: URL
@@ -1780,7 +1817,7 @@ struct CodeSigningEntitlementsSnapshot {
         var entries: [Entry] = []
         for candidate in codeSigningCandidates(in: appURL) {
             if let signedCode = try inspectSignedCode(at: candidate) {
-                entries.append(Entry(url: candidate, plistData: signedCode.entitlements))
+                entries.append(Entry(url: candidate, plistData: injectDisableLibraryValidation(signedCode.entitlements)))
             }
         }
         return CodeSigningEntitlementsSnapshot(entries: entries)


### PR DESCRIPTION
## Problem

On WeChat **4.1.12 (269341)**, `install` produces a bundle that crashes:

1. **At launch** — dyld aborts:
   ```
   Library not loaded: @rpath/WCDYWrapper.framework/.../WCDYWrapper
   ... not valid for use in process: mapping process and mapped file
   (non-platform) have different Team IDs
   ```
2. **At login** — SIGKILL with:
   ```
   Termination Reason: Namespace CODESIGNING, Code 2 Invalid Page
   Thread 105: pc=0x101198000  (Instruction Abort, Permission fault)
   ```
   `wechat.dylib` jumps into anonymously mmap'd RX memory (runtime-generated
   code next to `roam_server.framework`'s `__LINKEDIT`).

## Root cause

`a2388ff` switched re-signing to `--preserve-metadata=identifier,flags,runtime`
**plus** preserving the original entitlements. That correctly restores
sandbox/mic/camera/network permissions, but Hardened Runtime then enforces two
checks the original Developer-ID build passed but the ad-hoc build does not:

- WeChat's entitlements carry Tencent's Team ID (`5A4RE8SF68`) via
  `com.apple.application-identifier`, so AMFI treats the re-signed main binary
  as that Team ID while the re-signed frameworks are Team-less ad-hoc →
  library validation rejects `WCDYWrapper.framework`.
- Hardened Runtime rejects unsigned anonymous executable pages →
  `Invalid Page` when `wechat.dylib` runs its runtime-generated code at login.

(The pre-`a2388ff` `--force --deep --sign -` path avoided this by dropping
entitlements *and* the runtime flag — but that also lost sandbox permissions.)

## Fix

During the re-sign entitlement snapshot, inject two standard Hardened-Runtime
loosenings into every component that already carries entitlements:

- `com.apple.security.cs.disable-library-validation` — fixes the Team-ID mismatch
- `com.apple.security.cs.allow-unsigned-executable-memory` — covers non-`MAP_JIT`
  mmap'd RX trampolines used by the Tencent code path (same category as CEF)

These are exactly the entitlements mainstream macOS WeChat tweaks rely on; no
patch bytes or hook logic change.

## Verification

- macOS **15.7.7 (24G720)**, WeChat **4.1.12 (269341)**, arm64.
- `codesign --verify --deep --strict` passes; both entitlements present in the
  main binary.
- Before: launch → SIGKILL (WCDYWrapper); after disable-library-validation:
  login → SIGKILL (Invalid Page). After this PR: **launches and logs in with
  no crash** (`install --runtime-tip --block-update`).
- Runtime recall interception still pending a real revoke test, but the
  signing regression itself is resolved.

## Notes / follow-ups

- `disable-library-validation` is the conventional trade-off for ad-hoc tweaks;
  worth documenting in the FAQ alongside the existing TCC notes.
- If a future build still hits an unsigned-memory path, `allow-jit` (already in
  WeChat's entitlements) is the first thing to re-check.