### PR TITLE
feat: Intel 微信 4.1.13/269630 防撤回原型与实机双路径验证 (x86_64)

### DIFF
--- a/Docs/intel-269630-runtime-tip.md
+++ b/Docs/intel-269630-runtime-tip.md
@@ -1,0 +1,117 @@
+# Intel x86_64：微信 4.1.13 / 269630 runtime-tip 实测与参考实现
+
+Related to [#55](https://github.com/fzlzjerry/wechat-antirecall/issues/55)。
+
+**结论：实体 Intel Mac 上，独立的 x86_64 runtime hook 已能保留对方撤回的消息并显示 `[已拦截撤回]`，自己撤回仍走原生行为。**
+
+**范围：这是实验性参考实现和协作证据，不是 GUI/CLI 已支持 Intel 的发布声明。** 不修改 `patches.json`、SwiftPM target、发行架构或支持列表；不替 #55 的完整 Intel 发布验收打勾。这里的“新版本”只指下列实际测试的 build，不代表任何未来版本。
+
+## 测试环境和结果
+
+- 验收日期：2026-09-10。
+- 实体 Intel x86_64，macOS 13.7.8。
+- `CFBundleShortVersionString=4.1.13`、`CFBundleVersion=269630`。
+- 原 App `CFBundleIdentifier=com.tencent.xinWeChat`。
+- 编译独立 runtime：Apple clang 14.0.3、C++17、Foundation。
+- 本机 Swift 为 5.8.1，低于项目 manifest 的 5.9；未将独立 clang 自测说成整个 SwiftPM/GUI 编译通过。
+
+| 场景 | 实验副本 | 正式路径 `/Applications/WeChat.app` |
+| --- | --- | --- |
+| 对方撤回：原消息保留并显示 `[已拦截撤回]` | 用户人工确认通过 | 用户人工确认通过 |
+| 自己撤回：原消息移除、原生提示、无 `[已拦截撤回]` | 用户人工确认通过 | 用户人工确认通过 |
+| runtime 加载与 hook 安装 | 固定状态输出、映像检查通过 | 固定状态输出、映像检查通过 |
+| `codesign --verify --deep --strict` | 通过 | 通过（ad-hoc） |
+
+人工 UI 结果是测试者反馈，不是自动化截图或 E2E 断言；没有上传聊天截图、账号、消息、二维码或原始日志。登录/网络在测试期间可用，但尚无独立完整回归；麦克风、摄像头、所有消息类型、群聊、多语言、跨设备本人撤回、长期稳定性和实际回滚尚未完整验证。
+
+## 可复现文件
+
+- [参考 runtime](../Scripts/experimental/intel-269630/RuntimeTipIntel.mm)：正式路径版本的源码快照，保持与实机验收版本相同；仍保留实验时期的固定状态字符串。
+- [合成夹具](../Scripts/experimental/intel-269630/fixtures.S)：手写 assembly，非提取的微信二进制。
+- [受控测试](../Scripts/experimental/intel-269630/runtime_test.cpp)：调用真实 installer/wrapper，在当前测试进程的匿名内存上验证，不启动微信。
+- [测试入口](../Scripts/experimental/intel-269630/run_tests.py)：串行 Debug、Release、ASan/UBSan、重复运行及错误路径 dlopen 拒绝。
+- [只读预检](intel-preflight.md)：Python 标准库工具，区分 catalog 覆盖与业务验收，不安装补丁。
+
+需要 Python 3.10+ 与 macOS Command Line Tools。仓库根目录执行：
+
+```sh
+python3 -B -m unittest discover -s Scripts/tests -p 'test_intel_preflight.py' -v
+python3 -B Scripts/experimental/intel-269630/run_tests.py
+python3 -B Scripts/intel-preflight.py --app /path/to/original/WeChat.app --summary
+```
+
+第一项在合成 Mach-O 上验证 thin/fat、slice 范围、重复架构、CPU mismatch、路径逃逸与 catalog 解析；第二项要求 Intel macOS。构建输出只在临时目录，退出自动清理。没有自动安装、签名、停止或启动微信的入口。
+
+runtime 源码目前固定 `/Applications/WeChat.app`、`com.tencent.xinWeChat`、build、UUID、入口和 store 字节，不是可传任意 App 的通用 hook。**请勿直接复制 `.payload` 到现用 App；本 PR 不提供无人值守安装器。**
+
+## 原始二进制标识
+
+所有哈希取自修改前原件，不是 ad-hoc 重签后的二进制。
+
+| 项目 | 值 |
+| --- | --- |
+| 二进制 | `Contents/Resources/wechat.dylib` |
+| 完整 fat SHA-256 | `cb6cdce4af05ddfecd750f691b4370320d138d3802d19030d65bf8a0dbc99c12` |
+| x86_64 slice SHA-256 | `837c498eb1f7bf403948bdf53d5808e54d4173b46b62ed89890a1b4e0135dda6` |
+| x86_64 UUID | `93FCF137-72E5-34A1-82FE-9110EF54C3C3` |
+| slice 起点 / 长度 | `16384 / 178952288` bytes |
+
+## 只读定位证据
+
+地址为 x86_64 slice 内未 slide 的 VA，不是整个 fat 文件 offset。文件位置按 segment/section 映射；运行地址使用 dyld slide + VA。
+
+| 位置 | VA / 偏移 | 原始字节或语义 |
+| --- | --- | --- |
+| 撤回 parser 入口 | `0x512C510` | `554889E5415741564155415453` |
+| caller 的调用点 | `0x512C49E` | `E86D000000` → `call 0x512C510` |
+| newmsgid store | `0x512CD72` | `488983C8010000` → `mov qword ptr [rbx+0x1C8],rax` |
+| replaceMsg 访问 | `0x512CE08` | `4C8DB3D0010000` → `lea r14,[rbx+0x1D0]` |
+| 输出字段 | `+0x1C8 / +0x1D0` | `uint64_t newmsgid / libc++ std::string replaceMsg` |
+| parser ABI | 三参数 | `bool (void *, std::string *, void *)` |
+
+定位采用邻近官方 build 269629 作参考、函数边界与 Capstone 分块反汇编、caller 和字段指令交叉确认。字符串锚点包括 `revoke_climsgid`、`TryParseMessageX`、`ParseMessageXml`、`OnMessageRevoke`，但直接字符串 xref 扫描没有命中；**不是凭字符串地址打补丁**。分块扫描也不是完整反编译覆盖证明。
+
+未完成本 build 的 IDA Pro/Hex-Rays 全库交叉确认；此项是 #55 仍待维护者或协作者补齐的证据。函数入口已确认，但这里不提交未经独立复核的完整函数结束 VA。没有复用 #55 的 269574 地址。
+
+## hook 与双路径语义
+
+入口覆盖按完整指令边界取 13 bytes：`push rbp; mov rbp,rsp; push r15; push r14; push r13; push r12; push rbx`，没有 RIP-relative 指令。入口用 `movabs rax,<wrapper>; jmp rax; nop`；trampoline 重放原序言后用 `FF2500000000` 加绝对目标回到 `entry+13`，回跳不破坏寄存器或 flags。
+
+这不是通用 x86_64 relocator；新序言若含相对寻址或相对控制流，必须重新实现/验证，不能把本次 13-byte 长度照抄。安装只在加载初始化期间进行，不支持运行中异步热补丁。
+
+wrapper 先调用原 parser，保留原返回值。随后验证对象访问权限、24-byte libc++ 字符串布局、撤回 XML、唯一非零数字 `<newmsgid>` 与输出 ID 相等、原提示非空且含撤回语义。只有匹配的对方撤回才：
+
+1. `replaceMsg = "[已拦截撤回] " + 原生提示`；
+2. 字符串赋值成功后，再将 `newmsgid` 清零；
+3. 不修改 XML 或第三参数 flag。
+
+本人撤回识别：提示以 `You recalled `、`你撤回`、`你收回`、`你回收` 开头，或 XML 含对应片段时原样返回。这是**文案启发式，不是发送者身份验证**；可能因为昵称/XML 中出现这些词而跳过对方撤回，未覆盖的语言也不保证正确。对象、XML、ID 或字符串校验失败时不做后处理，保留原生路径。
+
+该原型没有通用 Message finalizer hook，没有 `{content}` 缓存、任意模板、更新阻止、红包自动化或 ARM64 适配。最初尝试把 7-byte store 改成更长清零指令被放弃，未把截断指令纳入方案。
+
+## 签名、加载与恢复经验
+
+- 修改 App 使腾讯原始签名失效。实测为 ad-hoc、`TeamIdentifier=not set`，不是保留厂商身份。
+- 从原件保存所有 entitlements；按组件恢复，最终主 App 显式使用原 plist 加 `com.apple.security.cs.disable-library-validation` 和 `com.apple.security.cs.allow-unsigned-executable-memory`。这会放宽安全限制，不能承诺账号零风险。
+- 最终保留 Sandbox、application-groups、allow-jit、Hardened Runtime，包括原 Team ID 绑定的 entitlement 值。不要仅因签名 TeamIdentifier 为空就删除这些值。
+- `--preserve-metadata=identifier,flags,runtime` **不包括 entitlements**；重新签外层 App 若不显式提供 plist，曾导致 entitlements 丢失，已在再次启动前恢复并回读比较。
+- `(runtime)` 与 `(adhoc,runtime)` 都表示包含 Hardened Runtime。旧审计器只精确匹配前者而误报，不能把输出格式当权限丢失。
+- 外加 `sandbox-exec`、临时 HOME 并拒绝正式 Containers 的测试曾在 `libsecinit_appsandbox` 初始化中 `SIGILL`，但正式路径正常启动。它们不是等价启动条件，不能据此断言 Team ID 是确定根因。
+- 绑定暂存路径的 payload 放到正式路径会主动拒绝。需使用 Formal 版本，检查唯一映像路径与 constructor/install 各一次。
+- 构建产物与可加载 dylib 分开存放，避免加载器发现两份 runtime。
+- 原 App 完整备份以及安装前 App 实体均保留；文件内容哈希、软链接、权限和签名验证通过。复制产生的 provenance/quarantine、ctime/mtime 差异分开记录，不删除系统安全属性。
+- 安装只操作 App 文件，未直接编辑/清理聊天数据库、Group Containers 或 Keychain；正常运行微信会自行读写数据。App 备份不等于聊天记录备份，不能保证数据或账号零风险。
+
+## 后续集成与验收缺口
+
+- 将独立 runtime 接入架构感知的 CLI/GUI 安装、卸载和 runtime 支持列表，而非仅增加 `patches.json` 条目。
+- 明确签名快照、替换回滚以及唯一目标 path/build/arch/hash 校验。
+- 原型的结构解析、字符串 ABI、初始化时线程安全及文案启发式需要进一步 review/hardening。
+- 增加真实恢复验证、麦克风/摄像头等权限回归以及更多消息类型、语言、跨设备和群聊测试。
+- 完整 IDA/Hex-Rays 证据与全项目 Intel build/CI 仍待补齐；不关闭 #55。
+
+## English summary
+
+An independent x86_64 parser-entry trampoline was verified on physical Intel macOS 13.7.8 with WeChat 4.1.13 **build 269630**. Both an isolated copy and the installed `/Applications/WeChat.app` passed user-reported manual checks: retain another person's recalled message with `[已拦截撤回]`, while preserving native self-recall behavior.
+
+This contribution contains the tested source snapshot, synthetic installer/wrapper tests and read-only preflight tooling. It does **not** claim universal Intel GUI/CLI support, future-build compatibility, full IDA/Hex-Rays validation, successful rollback testing, or absence of account/data risk. No WeChat binaries, private logs, screenshots or account data are included.

--- a/Docs/intel-preflight.md
+++ b/Docs/intel-preflight.md
@@ -1,0 +1,73 @@
+# Intel 只读预检工具
+
+这个脚本用于在本地对微信 App 做只读检查，不会修改、安装、重签名或联网。
+
+## 用途
+
+1. 读取指定 `WeChat.app` 的 `Info.plist`。
+2. 解析 `Contents/Resources/wechat.dylib`，识别 thin / fat Mach-O。
+3. 计算整个文件的 SHA-256；如果存在 x86_64 切片，也单独计算该切片的 SHA-256。
+4. 读取 `patches.json`，只按 catalog 判断 build / arch / feature 覆盖情况，不把 arm64 目标误报成 Intel 支持。
+5. 输出 JSON，或输出适合粘贴到 issue 的简短中文摘要。
+
+## 用法
+
+默认读取：
+
+- App：`/Applications/WeChat.app`
+- 配置：仓库根目录下的 `patches.json`
+
+示例：
+
+```sh
+python3 -B Scripts/intel-preflight.py
+python3 -B Scripts/intel-preflight.py --summary
+python3 -B Scripts/intel-preflight.py --app /Applications/WeChat.app --config patches.json --summary
+```
+
+## 输出说明
+
+JSON 输出包含：
+
+- `app`：bundle 标识、版本、构建号、二进制名
+- `binary`：Mach-O 类型、whole hash、x86_64 slice hash、各 slice 基本信息
+- `catalog`：当前 build 是否命中、目标数量、是否存在 Intel 覆盖
+- `host`：本机 Python/平台信息，以及 `swift` / `xcrun` 探针结果
+- `limitations`：明确标记这是只读目录预检，不代表补丁已安装或真实 Intel 实机验证通过
+
+摘要输出会明确提示：
+
+- 这是只读预检，不代表补丁已安装；
+- 这是目录内静态检查，不代表真实 Intel 实机验证通过；
+- 如果 catalog 只覆盖 arm64，摘要不会冒充 Intel 支持；
+- 探针命令失败不会中断主流程，只会回到 `status/detail` 字段。
+
+## 限制
+
+- 不执行写入、安装、签名、下载或网络请求。
+- 不读取聊天数据库、账号数据或其他敏感运行时信息。
+- 不把 bundle 外部的 symlink 目标当成合法的 `wechat.dylib`。
+- 不把重复架构、重叠 slice 或 CPU type 不一致的 fat Mach-O 当成正常样本。
+
+## 结果使用建议
+
+这个工具适合在 issue 里提供只读证据：
+
+- 当前安装版本与 build
+- x86_64 slice 的 SHA-256
+- catalog 命中的 build 和 feature 覆盖
+- 本机工具链版本信息
+
+## 测试命令
+
+在仓库根目录执行：
+
+```sh
+python3 -B -m unittest Scripts.tests.test_intel_preflight
+```
+
+它不能替代：
+
+- 真实 Intel 机器上的运行测试
+- 微信内真实 hook 或补丁生效验证
+- 生产安装前的人工审查

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -4,6 +4,8 @@
 
 用户向的使用说明在 [README.md](README.md)。
 
+Intel 协作见 [#55](https://github.com/fzlzjerry/wechat-antirecall/issues/55)。实体 Intel 上微信 4.1.13/build 269630 的独立 runtime、合成自测与双路径人工验收见 [Intel 269630 实测报告](Docs/intel-269630-runtime-tip.md)；这是实验性参考实现，不改变 GUI/CLI 或发行版支持范围。环境信息可使用 [Intel 只读预检](Docs/intel-preflight.md) 收集。
+
 实验性自动红包的协议、对象布局与 ABI 证据见 [红包逆向记录](Docs/red-packet-269624.md)。该功能复用已有消息 finalizer hook，默认关闭；目前适配 269624 与 269628，范围独立于防撤回构建表。
 
 ---

--- a/Scripts/experimental/intel-269630/RuntimeTipIntel.mm
+++ b/Scripts/experimental/intel-269630/RuntimeTipIntel.mm
@@ -1,0 +1,276 @@
+#import <Foundation/Foundation.h>
+#include <mach/mach.h>
+#include <mach/mach_vm.h>
+#include <mach-o/dyld.h>
+#include <mach-o/loader.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <dlfcn.h>
+#include <execinfo.h>
+#include <array>
+#include <atomic>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <limits>
+#include <string>
+
+#if !defined(__x86_64__)
+#error 此实验只支持 Intel x86_64
+#endif
+
+namespace {
+using Parser = bool (*)(void *, std::string *, void *);
+Parser original = nullptr;
+constexpr std::array<uint8_t, 13> expected = {0x55,0x48,0x89,0xe5,0x41,0x57,0x41,0x56,0x41,0x55,0x41,0x54,0x53};
+constexpr uint8_t expectedUUID[] = {0x93,0xfc,0xf1,0x37,0x72,0xe5,0x34,0xa1,0x82,0xfe,0x91,0x10,0xef,0x54,0xc3,0xc3};
+std::atomic<unsigned> events{0};
+
+void logStatus(const char *status) {
+    // 只记录状态，不记录 XML、消息内容、账号或消息 ID。
+    std::fprintf(stderr, "[RuntimeTipIntel] pid=%d %s\n", getpid(), status);
+    std::fflush(stderr);
+}
+
+bool accessible(const void *pointer, size_t length, vm_prot_t required) {
+    if (!pointer || !length) return false;
+    mach_vm_address_t cursor = reinterpret_cast<mach_vm_address_t>(pointer);
+    if (length > std::numeric_limits<mach_vm_address_t>::max() - cursor) return false;
+    const auto end = cursor + length;
+    while (cursor < end) {
+        mach_vm_address_t address = cursor;
+        mach_vm_size_t size = 0;
+        natural_t depth = 0;
+        vm_region_submap_info_data_64_t info{};
+        while (true) {
+            mach_msg_type_number_t count = VM_REGION_SUBMAP_INFO_COUNT_64;
+            auto result = mach_vm_region_recurse(mach_task_self(), &address, &size, &depth,
+                                      reinterpret_cast<vm_region_recurse_info_t>(&info), &count);
+            if (result != KERN_SUCCESS || address > cursor || size == 0) return false;
+            if (!info.is_submap) break;
+            if (++depth > 32) return false;
+        }
+        if ((info.protection & required) != required || size > UINT64_MAX-address) return false;
+        auto next = address+size;
+        if (next <= cursor) return false;
+        cursor = next;
+    }
+    return true;
+}
+
+bool copyString(const void *object, std::string &output, bool writable = false) {
+    // 先按已核对的 libc++ 默认布局检查，不直接调用陌生对象的 size()/data()。
+    if (!accessible(object, 24, VM_PROT_READ | (writable ? VM_PROT_WRITE : 0))) return false;
+    uint64_t words[3];
+    std::memcpy(words, object, sizeof(words));
+    const auto *bytes = reinterpret_cast<const uint8_t *>(words);
+    const char *data = nullptr;
+    size_t length = 0;
+    if (bytes[0] & 1) {
+        uint64_t capacity = words[0] & ~uint64_t(1);
+        length = words[1];
+        if (capacity < 24 || capacity > (1u<<22) || length >= capacity || length > (1u<<20)) return false;
+        data = reinterpret_cast<const char *>(words[2]);
+        if (!accessible(data, length+1, VM_PROT_READ | (writable ? VM_PROT_WRITE : 0))) return false;
+    } else {
+        length = bytes[0] >> 1;
+        if (length > 22) return false;
+        data = static_cast<const char *>(object)+1;
+    }
+    if (data[length] != '\0') return false;
+    output.assign(data, length);
+    return true;
+}
+
+bool localABI() {
+    if (sizeof(std::string) != 24) return false;
+    std::string shortValue = "abc", longValue(100, 'x'), value;
+    return copyString(&shortValue, value) && value == shortValue &&
+           copyString(&longValue, value) && value == longValue;
+}
+
+bool xmlID(const std::string &xml, uint64_t &value) {
+    const std::string open = "<newmsgid>", close = "</newmsgid>";
+    auto start = xml.find(open);
+    if (start == std::string::npos || xml.find(open, start+open.size()) != std::string::npos) return false;
+    start += open.size();
+    auto end = xml.find(close, start);
+    if (end == std::string::npos || end == start || end-start > 20) return false;
+    uint64_t n = 0;
+    for (size_t i = start; i < end; ++i) {
+        char c = xml[i];
+        if (c < '0' || c > '9' || n > (UINT64_MAX-static_cast<unsigned>(c-'0'))/10) return false;
+        n = n*10 + static_cast<unsigned>(c-'0');
+    }
+    value = n;
+    return n != 0;
+}
+
+bool selfTip(const std::string &tip) {
+    // 与仓库一致地保留本人撤回；只匹配起始文案，降低昵称误匹配。
+    for (const char *prefix : {"You recalled ", "你撤回", "你收回", "你回收"}) {
+        if (tip.rfind(prefix, 0) == 0) return true;
+    }
+    return false;
+}
+
+bool wrapper(void *message, std::string *xmlObject, void *flag) {
+    const bool result = original(message, xmlObject, flag);
+    if (!result || !message || !xmlObject) return result;
+    try {
+        std::string xml, tip;
+        auto *base = static_cast<uint8_t *>(message);
+        if (!copyString(xmlObject, xml) ||
+            (xml.find("<revokemsg>") == std::string::npos && xml.find("<revokemsg ") == std::string::npos) ||
+            !accessible(base+0x1c8, 8, VM_PROT_READ | VM_PROT_WRITE) ||
+            !copyString(base+0x1d0, tip, true)) return result;
+        if (selfTip(tip)) return result;
+        // 本人提示在 XML 中出现时也保留，不修改 flag 或原始 XML。
+        if (xml.find("你撤回") != std::string::npos || xml.find("You recalled ") != std::string::npos ||
+            xml.find("你收回") != std::string::npos || xml.find("你回收") != std::string::npos) return result;
+        uint64_t parsed = 0, actual = 0;
+        std::memcpy(&actual, base+0x1c8, sizeof(actual));
+        if (!xmlID(xml, parsed) || parsed != actual || tip.empty() ||
+            (tip.find("撤回") == std::string::npos && tip.find(" recalled ") == std::string::npos)) return result;
+        // 先完成可能分配内存的字符串写入，再清零 ID；失败时保留原始删除语义。
+        auto *replace = reinterpret_cast<std::string *>(base+0x1d0);
+        replace->assign("[已拦截撤回] " + tip);
+        uint64_t zero = 0;
+        std::memcpy(base+0x1c8, &zero, sizeof(zero));
+        if (events.fetch_add(1) < 10) logStatus("recall intercepted; tip replaced (content not logged)");
+    } catch (...) {
+        logStatus("wrapper allocation/validation failure; keeping native result");
+    }
+    return result;
+}
+
+bool install(void *entry) {
+    if (original) { logStatus("refused: already installed in this runtime instance"); return false; }
+    if (!localABI()) { logStatus("refused: local libc++ layout mismatch"); return false; }
+    if (!accessible(entry, expected.size(), VM_PROT_READ | VM_PROT_EXECUTE)) {
+        logStatus("refused: entry unreadable or not executable"); return false;
+    }
+    if (std::memcmp(entry, expected.data(), expected.size()) != 0) {
+        logStatus("refused: entry expected bytes mismatch"); return false;
+    }
+    size_t pageSize = static_cast<size_t>(sysconf(_SC_PAGESIZE));
+    auto start = reinterpret_cast<uintptr_t>(entry);
+    auto page = start & ~(pageSize-1);
+    if (start+expected.size() > page+pageSize) return false;
+    // trampoline 在入口发布之前完成初始化；不支持运行中异步热安装。
+    void *memory = mmap(nullptr, pageSize, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, -1, 0);
+    if (memory == MAP_FAILED) { logStatus("refused: mmap RW failed"); return false; }
+    uint8_t buffer[27]{};
+    std::memcpy(buffer, expected.data(), expected.size());
+    const uint8_t jump[] = {0xff,0x25,0,0,0,0};
+    std::memcpy(buffer+13, jump, sizeof(jump));
+    uintptr_t continuation = start+13;
+    std::memcpy(buffer+19, &continuation, sizeof(continuation));
+    std::memcpy(memory, buffer, sizeof(buffer));
+    if (mprotect(memory, pageSize, PROT_READ | PROT_EXEC) != 0) {
+        logStatus("refused: trampoline RX protection failed"); munmap(memory,pageSize); return false;
+    }
+    if (!accessible(memory,sizeof(buffer),VM_PROT_READ | VM_PROT_EXECUTE)) {
+        munmap(memory,pageSize); return false;
+    }
+    uint8_t patch[13] = {0x48,0xb8};
+    uintptr_t replacement = reinterpret_cast<uintptr_t>(&wrapper);
+    std::memcpy(patch+2,&replacement,sizeof(replacement));
+    patch[10]=0xff; patch[11]=0xe0; patch[12]=0x90;
+    if (std::memcmp(entry,expected.data(),expected.size()) != 0 ||
+        mach_vm_protect(mach_task_self(),page,pageSize,FALSE,VM_PROT_READ|VM_PROT_WRITE|VM_PROT_COPY)!=KERN_SUCCESS) {
+        logStatus("refused: target code COW write permission failed"); munmap(memory,pageSize); return false;
+    }
+    original = reinterpret_cast<Parser>(memory);
+    std::memcpy(entry,patch,sizeof(patch));
+    __builtin___clear_cache(static_cast<char *>(entry),static_cast<char *>(entry)+sizeof(patch));
+    if (mach_vm_protect(mach_task_self(),page,pageSize,FALSE,VM_PROT_READ|VM_PROT_EXECUTE)!=KERN_SUCCESS) {
+        // 无法恢复代码页权限时不允许继续启动实验 App。
+        logStatus("fatal: cannot restore RX protection");
+        _exit(78);
+    }
+    if (!accessible(entry,expected.size(),VM_PROT_READ|VM_PROT_EXECUTE) ||
+        std::memcmp(entry,patch,sizeof(patch))!=0) {
+        logStatus("fatal: hook readback failed"); _exit(78);
+    }
+    logStatus("hook installed; expected bytes, trampoline and RX readback verified");
+    return true;
+}
+
+#ifndef RTI_SELFTEST
+void imageAdded(const mach_header *raw, intptr_t slide) {
+    if (raw->magic!=MH_MAGIC_64 || raw->cputype!=CPU_TYPE_X86_64) return;
+    auto *header = reinterpret_cast<const mach_header_64 *>(raw);
+    const uint8_t *cursor = reinterpret_cast<const uint8_t *>(header)+sizeof(*header);
+    bool uuidOK=false, textOK=false;
+    for (uint32_t i=0; i<header->ncmds; ++i) {
+        auto *lc = reinterpret_cast<const load_command *>(cursor);
+        if (lc->cmd==LC_UUID) {
+            auto *uuid = reinterpret_cast<const uuid_command *>(cursor);
+            uuidOK=std::memcmp(uuid->uuid,expectedUUID,sizeof(expectedUUID))==0;
+        }
+        if (lc->cmd==LC_SEGMENT_64) {
+            auto *seg=reinterpret_cast<const segment_command_64 *>(cursor);
+            auto *sections=reinterpret_cast<const section_64 *>(seg+1);
+            for (uint32_t j=0; j<seg->nsects; ++j) {
+                auto &s=sections[j];
+                if (std::strncmp(s.sectname,"__text",16)==0 && s.addr<=0x512c510 && 0x512cd79<s.addr+s.size) textOK=true;
+            }
+        }
+        cursor+=lc->cmdsize;
+    }
+    if (!uuidOK || !textOK || original) return;
+    auto *entry=reinterpret_cast<uint8_t *>(slide+0x512c510);
+    const uint8_t store[]={0x48,0x89,0x83,0xc8,0x01,0,0};
+    if (!accessible(reinterpret_cast<void *>(slide+0x512cd72),sizeof(store),VM_PROT_READ) ||
+        std::memcmp(reinterpret_cast<void *>(slide+0x512cd72),store,sizeof(store))!=0) {
+        logStatus("refused: newmsgid anchor mismatch"); return;
+    }
+    if (!install(entry)) logStatus("refused: hook installation preconditions failed");
+}
+#endif
+}
+
+#ifdef RTI_SELFTEST
+extern "C" bool rti_test_install(void *entry) { return install(entry); }
+extern "C" unsigned rti_test_events() { return events.load(); }
+#else
+__attribute__((constructor)) static void initialize() {
+    // 仅输出映像、函数地址和调用链，不记录业务参数或消息。
+    Dl_info own{};
+    constexpr const char *runtimePath="/Applications/WeChat.app/Contents/Resources/RuntimeTipIntel.dylib";
+    if (!dladdr(reinterpret_cast<const void *>(&initialize), &own) || !own.dli_fname ||
+        std::strcmp(own.dli_fname,runtimePath)!=0) {
+        logStatus("refused: runtime image outside exact experiment Resources path"); return;
+    }
+    if (std::getenv("RTI_TRACE_INIT") != nullptr) {
+    std::fprintf(stderr,"[RuntimeTipIntel] pid=%d init-trace base=%p state=%p original=%p path=%s\n",
+                 getpid(),own.dli_fbase,static_cast<void *>(&original),reinterpret_cast<void *>(original),
+                 own.dli_fname ? own.dli_fname : "unknown");
+    void *frames[16];
+    int count=backtrace(frames,16);
+    for (int i=0;i<count;++i) {
+        Dl_info info{};
+        if (dladdr(frames[i],&info)) {
+            const char *name=info.dli_fname ? std::strrchr(info.dli_fname,'/') : nullptr;
+            std::fprintf(stderr,"[RuntimeTipIntel] pid=%d init-frame=%d image=%s offset=0x%llx symbol=%s\n",
+                         getpid(),i,name ? name+1 : "unknown",
+                         static_cast<unsigned long long>(reinterpret_cast<uintptr_t>(frames[i])-reinterpret_cast<uintptr_t>(info.dli_fbase)),
+                         info.dli_sname ? info.dli_sname : "unknown");
+        }
+    }
+    }
+    @autoreleasepool {
+        NSBundle *bundle=[NSBundle mainBundle];
+        NSString *expectedPath=@"/Applications/WeChat.app";
+        if (![[bundle bundlePath] isEqualToString:expectedPath] ||
+            ![[bundle bundleIdentifier] isEqualToString:@"com.tencent.xinWeChat"] ||
+            ![[bundle objectForInfoDictionaryKey:@"CFBundleVersion"] isEqualToString:@"269630"]) {
+            logStatus("refused: experiment bundle identity/path/build mismatch"); return;
+        }
+        logStatus("runtime loaded in exact experiment bundle");
+        _dyld_register_func_for_add_image(imageAdded);
+    }
+}
+#endif

--- a/Scripts/experimental/intel-269630/fixtures.S
+++ b/Scripts/experimental/intel-269630/fixtures.S
@@ -1,0 +1,154 @@
+#if !defined(__x86_64__)
+#error 此自测只支持 x86_64
+#endif
+
+.text
+.p2align 4
+.globl _fixture_start
+.globl _fixture_end
+_fixture_start:
+    // 与只读样本一致的 13 字节完整序言，不包含相对寻址指令。
+    pushq %rbp
+    movq %rsp, %rbp
+    pushq %r15
+    pushq %r14
+    pushq %r13
+    pushq %r12
+    pushq %rbx
+    subq $8, %rsp
+    // 主动改写非易失寄存器，确保测试能检测到漏恢复。
+    movq $101, %rbp
+    movq $102, %rbx
+    movq $103, %r12
+    movq $104, %r13
+    movq $105, %r14
+    movq $106, %r15
+    // 复制到匿名内存后，将此唯一占位值替换为自测 body_entry 地址。
+    movabsq $0x1122334455667788, %rax
+    callq *%rax
+    addq $8, %rsp
+    popq %rbx
+    popq %r12
+    popq %r13
+    popq %r14
+    popq %r15
+    popq %rbp
+    retq
+_fixture_end:
+
+.p2align 4
+.globl _wrapper_entry
+_wrapper_entry:
+    // 在编译器序言之前捕获真实入口栈对齐，作为第四参数传递。
+    movq %rsp, %rcx
+    andq $15, %rcx
+    jmp _wrapper_impl
+
+.p2align 4
+.globl _body_entry
+_body_entry:
+    movq %rsp, %rcx
+    andq $15, %rcx
+    jmp _body_impl
+
+.p2align 4
+.globl _checked_invoke
+_checked_invoke:
+    // 参数为 target、message、xml、probe、resultOut。
+    pushq %rbp
+    pushq %r15
+    pushq %r14
+    pushq %r13
+    pushq %r12
+    pushq %rbx
+    subq $40, %rsp
+    movq %r8, 0(%rsp)
+    movq %rsp, 8(%rsp)
+    movq $0x654321, 24(%rsp)
+    movq %rdi, %rax
+    movq %rsi, %rdi
+    movq %rdx, %rsi
+    movq %rcx, %rdx
+    movq $0x1234501, %rbp
+    movq $0x1234502, %rbx
+    movq $0x1234503, %r12
+    movq $0x1234504, %r13
+    movq $0x1234505, %r14
+    movq $0x1234506, %r15
+    callq *%rax
+    movq 0(%rsp), %rcx
+    movb %al, (%rcx)
+    xorl %eax, %eax
+    cmpq $0x1234501, %rbp
+    setne %dl
+    movzbl %dl, %edx
+    orl %edx, %eax
+    cmpq $0x1234502, %rbx
+    setne %dl
+    movzbl %dl, %edx
+    shll $1, %edx
+    orl %edx, %eax
+    cmpq $0x1234503, %r12
+    setne %dl
+    movzbl %dl, %edx
+    shll $2, %edx
+    orl %edx, %eax
+    cmpq $0x1234504, %r13
+    setne %dl
+    movzbl %dl, %edx
+    shll $3, %edx
+    orl %edx, %eax
+    cmpq $0x1234505, %r14
+    setne %dl
+    movzbl %dl, %edx
+    shll $4, %edx
+    orl %edx, %eax
+    cmpq $0x1234506, %r15
+    setne %dl
+    movzbl %dl, %edx
+    shll $5, %edx
+    orl %edx, %eax
+    cmpq 8(%rsp), %rsp
+    setne %dl
+    movzbl %dl, %edx
+    shll $6, %edx
+    orl %edx, %eax
+    cmpq $0x654321, 24(%rsp)
+    setne %dl
+    movzbl %dl, %edx
+    shll $7, %edx
+    orl %edx, %eax
+    testq $15, %rsp
+    setne %dl
+    movzbl %dl, %edx
+    shll $8, %edx
+    orl %edx, %eax
+    addq $40, %rsp
+    popq %rbx
+    popq %r12
+    popq %r13
+    popq %r14
+    popq %r15
+    popq %rbp
+    retq
+
+.p2align 4
+.globl _rip_fixture_start
+.globl _rip_fixture_end
+_rip_fixture_start:
+    // 前 13 字节包含一个 RIP-relative load，随后保留 rax 与 ZF。
+    movq L_rip_value(%rip), %rax
+    addq %rsi, %rax
+    nop
+    nop
+    nop
+    jz L_rip_zero
+    addq $1, %rax
+    retq
+L_rip_zero:
+    movq $0x77, %rax
+    retq
+.p2align 3
+L_rip_value:
+    .quad 0x12345678
+_rip_fixture_end:

--- a/Scripts/experimental/intel-269630/run_tests.py
+++ b/Scripts/experimental/intel-269630/run_tests.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""只构建并运行合成夹具；不启动、注入、签名或修改微信。"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import platform
+import subprocess
+import sys
+import tempfile
+
+ROOT = Path(__file__).resolve().parent
+
+
+def run(args: list[str | Path], env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        [str(arg) for arg in args], cwd=ROOT, env=env,
+        capture_output=True, text=True, timeout=120,
+    )
+    print(result.stdout, end="")
+    print(result.stderr, end="", file=sys.stderr)
+    result.check_returncode()
+    return result
+
+
+def main() -> None:
+    if platform.system() != "Darwin" or platform.machine() != "x86_64":
+        raise SystemExit("需要原生 Intel x86_64 macOS；本脚本不声称验证 arm64/Rosetta")
+    # 不将 Agent 密钥或 DYLD 配置传给测试子进程。
+    env = {key: os.environ[key] for key in ("HOME", "PATH", "TMPDIR", "DEVELOPER_DIR", "SDKROOT") if key in os.environ}
+    env.setdefault("PATH", "/usr/bin:/bin:/usr/sbin:/sbin")
+    with tempfile.TemporaryDirectory(prefix="wechat-intel-selftest-") as directory:
+        out = Path(directory)
+        fixture = out / "fixtures.o"
+        run(["xcrun", "clang", "-arch", "x86_64", "-c", ROOT / "fixtures.S", "-o", fixture], env)
+        common = ["xcrun", "clang++", "-arch", "x86_64", "-std=c++17", "-Wall", "-Wextra", "-Werror", "-g"]
+        configs = {
+            "debug": ["-O0"],
+            "release": ["-O2", "-DNDEBUG"],
+            "sanitized": ["-O1", "-fsanitize=address,undefined", "-fno-sanitize-recover=all"],
+        }
+        for name, flags in configs.items():
+            binary = out / name
+            run(common + flags + [
+                "-Wno-unused-const-variable", "-DRTI_SELFTEST",
+                ROOT / "RuntimeTipIntel.mm", ROOT / "runtime_test.cpp", fixture,
+                "-framework", "Foundation", "-o", binary,
+            ], env)
+            result = run([binary], env)
+            if "PASS: actual runtime installer/wrapper: 100 cases" not in result.stdout:
+                raise RuntimeError("缺少完整自测结果")
+            print(f"PASS: {name}")
+        for _ in range(5):
+            run([out / "release"], env)
+        # 编译真实构造函数，并在非微信进程、非目标路径加载，必须拒绝安装 hook。
+        payload = out / "RuntimeTipIntel.payload"
+        run(common + [
+            "-O2", "-dynamiclib", ROOT / "RuntimeTipIntel.mm", "-framework", "Foundation",
+            "-Wl,-install_name,@loader_path/RuntimeTipIntel.dylib", "-o", payload,
+        ], env)
+        result = run([
+            sys.executable, "-c",
+            "import ctypes,sys; ctypes.CDLL(sys.argv[1]); print('dlopen returned safely')",
+            payload,
+        ], env)
+        refusal = "refused: runtime image outside exact experiment Resources path"
+        if result.stderr.count(refusal) != 1 or "hook installed;" in result.stderr:
+            raise RuntimeError("错误路径保护没有明确拒绝")
+        print("PASS: production constructor wrong-path rejection")
+    print("PASS: all synthetic tests; no WeChat process was launched or modified")
+
+
+if __name__ == "__main__":
+    main()

--- a/Scripts/experimental/intel-269630/runtime_test.cpp
+++ b/Scripts/experimental/intel-269630/runtime_test.cpp
@@ -1,0 +1,83 @@
+#include <sys/mman.h>
+#include <unistd.h>
+#include <array>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+extern "C" {
+extern const uint8_t fixture_start[], fixture_end[];
+bool rti_test_install(void *);
+unsigned rti_test_events();
+unsigned checked_invoke(bool (*)(void *, std::string *, void *), void *, std::string *, void *, bool *);
+bool body_entry(void *,std::string *,void *);
+}
+struct Message {
+    std::array<uint8_t,0x1c0> pad{};
+    uint64_t before=0x123456789abcdef0ULL;
+    uint64_t id=0;
+    std::string tip;
+    uint64_t after=0xfedcba9876543210ULL;
+};
+static_assert(offsetof(Message,id)==0x1c8 && offsetof(Message,tip)==0x1d0);
+struct Probe {
+    void *message;
+    std::string *xml;
+    std::string tip;
+    uint64_t id;
+    bool result;
+    unsigned calls=0;
+};
+void check(bool value,const char *message) {
+    if (!value) { std::fprintf(stderr,"FAIL %s\n",message);std::exit(1); }
+}
+extern "C" bool body_impl(void *message,std::string *xml,void *context,uintptr_t alignment) {
+    auto *probe=static_cast<Probe *>(context);
+    check(message==probe->message && xml==probe->xml && alignment==8,"parser ABI");
+    auto *msg=static_cast<Message *>(message);
+    msg->id=probe->id;msg->tip=probe->tip; ++probe->calls;
+    return probe->result;
+}
+extern "C" bool wrapper_impl(void *,std::string *,void *,uintptr_t) { std::abort(); }
+int main() {
+    size_t page=static_cast<size_t>(sysconf(_SC_PAGESIZE));
+    auto *memory=static_cast<uint8_t *>(mmap(nullptr,page,PROT_READ|PROT_WRITE,MAP_ANON|MAP_PRIVATE,-1,0));
+    check(memory!=MAP_FAILED,"mmap");
+    size_t size=reinterpret_cast<uintptr_t>(fixture_end)-reinterpret_cast<uintptr_t>(fixture_start);
+    std::memcpy(memory,fixture_start,size);
+    uint64_t marker=0x1122334455667788ULL;
+    uintptr_t destination=reinterpret_cast<uintptr_t>(&body_entry);
+    unsigned replaced=0;
+    for (size_t i=0;i+8<=size;++i) if (std::memcmp(memory+i,&marker,8)==0) {
+        std::memcpy(memory+i,&destination,8); ++replaced;
+    }
+    check(replaced==1,"one body address");
+    check(mprotect(memory,page,PROT_READ|PROT_EXEC)==0,"RX mapping");
+    check(rti_test_install(memory),"actual runtime installer");
+    check(!rti_test_install(memory),"reject duplicate hook install");
+    auto target=reinterpret_cast<bool (*)(void *,std::string *,void *)>(memory);
+    for (unsigned i=0;i<100;++i) {
+        Message msg;
+        std::string xml="<sysmsg type=\"revokemsg\"><revokemsg><newmsgid>12345</newmsgid><replacemsg><![CDATA[张三撤回了一条消息]]></replacemsg></revokemsg></sysmsg>";
+        Probe probe{&msg,&xml,"张三撤回了一条消息",12345,true};
+        bool changed=true;
+        switch (i%5) {
+            case 1: probe.tip="你撤回了一条消息";changed=false;break;
+            case 2: probe.id=999;changed=false;break;
+            case 3: probe.result=false;changed=false;break;
+            case 4: probe.tip="\""+std::string(300,'A')+"\" recalled a message";break;
+        }
+        std::string expected=probe.tip;
+        bool result=false;
+        check(checked_invoke(target,&msg,&xml,&probe,&result)==0,"registers/stack canaries");
+        check(result==probe.result && probe.calls==1,"return preserved/original exactly once");
+        check(msg.id==(changed?0:probe.id),"id policy");
+        check(msg.tip==(changed?"[已拦截撤回] "+expected:expected),"actual runtime tip wrapper");
+        check(msg.before==0x123456789abcdef0ULL && msg.after==0xfedcba9876543210ULL,"adjacent canaries");
+    }
+    check(rti_test_events()==40,"event count");
+    check(munmap(memory,page)==0,"release fixture");
+    std::puts("PASS: actual runtime installer/wrapper: 100 cases; ABI, strings, self-recall, mismatch, false result, duplicate install");
+}

--- a/Scripts/intel-preflight.py
+++ b/Scripts/intel-preflight.py
@@ -1,0 +1,750 @@
+#!/usr/bin/env python3
+"""Read-only Intel preflight for WeChat on macOS.
+
+The tool inspects a target .app bundle, parses the bundled wechat.dylib as a
+thin or fat Mach-O, computes streaming SHA-256 digests, and reports only what
+is covered by the local patch catalog.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import plistlib
+import platform
+import re
+import subprocess
+import struct
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+JSON_SCHEMA_VERSION = 1
+DEFAULT_APP_PATH = "/Applications/WeChat.app"
+DEFAULT_CONFIG_PATH = str(Path(__file__).resolve().parents[1] / "patches.json")
+DEFAULT_BINARY_RELATIVE_PATH = "Contents/Resources/wechat.dylib"
+
+MH_MAGIC_64 = 0xFEEDFACF
+FAT_MAGIC = 0xCAFEBABE
+FAT_MAGIC_64 = 0xCAFEBABF
+LC_SEGMENT_64 = 0x19
+CPU_TYPE_X86_64 = 0x01000007
+CPU_TYPE_ARM64 = 0x0100000C
+
+FEATURE_BY_IDENTIFIER = {
+    "revoke": "silent",
+    "revoke-tip": "tip",
+    "runtime-tip": "runtime-tip",
+    "update": "block-update",
+    "multiInstance": "multi-instance",
+    "multiInstance-extra": "multi-instance-extra",
+}
+
+ARCH_BY_CPU_TYPE = {
+    CPU_TYPE_X86_64: "x86_64",
+    CPU_TYPE_ARM64: "arm64",
+}
+
+
+class PreflightError(Exception):
+    def __init__(self, kind: str, message: str, *, details: dict[str, Any] | None = None):
+        super().__init__(message)
+        self.kind = kind
+        self.message = message
+        self.details = details or {}
+
+    def to_payload(self) -> dict[str, Any]:
+        payload = {"kind": self.kind, "message": self.message}
+        payload.update(
+            {
+                k: v
+                for k, v in self.details.items()
+                if v is not None and "path" not in k.lower()
+            }
+        )
+        return payload
+
+
+@dataclass(frozen=True)
+class AppInfo:
+    app_path: Path
+    bundle_identifier: str
+    marketing_version: str
+    build_version: str
+    executable_name: str
+    binary_path: Path
+
+
+@dataclass(frozen=True)
+class HostInfo:
+    python_version: str
+    implementation: str
+    platform: str
+    executable: str
+    machine: str
+    macos_version: str
+    swift_probe: "ProbeResult"
+    macos_sdk_version_probe: "ProbeResult"
+    macos_sdk_platform_probe: "ProbeResult"
+
+
+@dataclass(frozen=True)
+class ProbeResult:
+    status: str
+    detail: str
+    exit_code: int | None = None
+
+
+@dataclass(frozen=True)
+class MachOSlice:
+    arch: str
+    offset: int
+    size: int
+    sha256: str
+    segments: list[dict[str, Any]]
+
+
+@dataclass(frozen=True)
+class BinaryReport:
+    path: str
+    kind: str
+    sha256: str
+    x86_64_slice_sha256: str | None
+    slices: list[MachOSlice]
+
+
+@dataclass(frozen=True)
+class ConfigTargetReport:
+    identifier: str
+    feature: str
+    arches: list[str]
+    entry_count: int
+    intel_covered: bool
+
+
+@dataclass(frozen=True)
+class CatalogReport:
+    path: str
+    build_version: str
+    build_matched: bool
+    target_count: int
+    intel_covered: bool
+    targets: list[ConfigTargetReport]
+
+
+@dataclass(frozen=True)
+class Report:
+    schema_version: int
+    app: AppInfo
+    binary: BinaryReport
+    catalog: CatalogReport
+    host: HostInfo
+    summary: str
+
+    def to_jsonable(self) -> dict[str, Any]:
+        return {
+            "schemaVersion": self.schema_version,
+            "app": {
+                "path": safe_basename(self.app.app_path),
+                "bundleIdentifier": self.app.bundle_identifier,
+                "marketingVersion": self.app.marketing_version,
+                "buildVersion": self.app.build_version,
+                "executable": self.app.executable_name,
+                "binaryPath": self.app.binary_path.name,
+            },
+            "binary": {
+                "path": Path(self.binary.path).name,
+                "kind": self.binary.kind,
+                "sha256": self.binary.sha256,
+                "x86_64SliceSha256": self.binary.x86_64_slice_sha256,
+                "slices": [
+                    {
+                        "arch": slice_.arch,
+                        "offset": slice_.offset,
+                        "size": slice_.size,
+                        "sha256": slice_.sha256,
+                        "segments": slice_.segments,
+                    }
+                    for slice_ in self.binary.slices
+                ],
+            },
+            "catalog": {
+                "path": Path(self.catalog.path).name,
+                "buildVersion": self.catalog.build_version,
+                "buildMatched": self.catalog.build_matched,
+                "targetCount": self.catalog.target_count,
+                "intelCovered": self.catalog.intel_covered,
+                "targets": [
+                    {
+                        "identifier": item.identifier,
+                        "feature": item.feature,
+                        "arches": item.arches,
+                        "entryCount": item.entry_count,
+                        "intelCovered": item.intel_covered,
+                    }
+                    for item in self.catalog.targets
+                ],
+            },
+            "host": {
+                "pythonVersion": self.host.python_version,
+                "implementation": self.host.implementation,
+                "platform": self.host.platform,
+                "executable": Path(self.host.executable).name,
+                "machine": self.host.machine,
+                "macosVersion": self.host.macos_version,
+                "swiftProbe": {
+                    "status": self.host.swift_probe.status,
+                    "detail": self.host.swift_probe.detail,
+                    "exitCode": self.host.swift_probe.exit_code,
+                },
+                "macosSdkVersionProbe": {
+                    "status": self.host.macos_sdk_version_probe.status,
+                    "detail": self.host.macos_sdk_version_probe.detail,
+                    "exitCode": self.host.macos_sdk_version_probe.exit_code,
+                },
+                "macosSdkPlatformProbe": {
+                    "status": self.host.macos_sdk_platform_probe.status,
+                    "detail": self.host.macos_sdk_platform_probe.detail,
+                    "exitCode": self.host.macos_sdk_platform_probe.exit_code,
+                },
+            },
+            "limitations": [
+                "只读目录预检",
+                "不写入、不安装、不签名、不联网",
+                "非 Swift CLI dry-run",
+                "不代表真实 Intel 实机已验证",
+            ],
+            "summary": self.summary,
+        }
+
+
+class ReadOnlyFile:
+    def __init__(self, path: Path):
+        self.path = path
+        self._fh = path.open("rb")
+
+    def close(self) -> None:
+        self._fh.close()
+
+    def read_at(self, offset: int, size: int) -> bytes:
+        self._fh.seek(offset)
+        data = self._fh.read(size)
+        if len(data) != size:
+            raise PreflightError(
+                "truncatedMachO",
+                "Mach-O 文件内容不足，无法完成解析",
+                details={"path": str(self.path), "offset": offset, "requested": size, "read": len(data)},
+            )
+        return data
+
+    def iter_range(self, offset: int, size: int, chunk_size: int = 1024 * 1024):
+        remaining = size
+        cursor = offset
+        while remaining:
+            take = min(chunk_size, remaining)
+            self._fh.seek(cursor)
+            chunk = self._fh.read(take)
+            if len(chunk) != take:
+                raise PreflightError(
+                    "truncatedMachO",
+                    "Mach-O 文件内容不足，无法完成解析",
+                    details={"path": str(self.path), "offset": cursor, "requested": take, "read": len(chunk)},
+                )
+            yield chunk
+            remaining -= take
+            cursor += take
+
+    def digest_range(self, offset: int, size: int) -> str:
+        hasher = hashlib.sha256()
+        for chunk in self.iter_range(offset, size):
+            hasher.update(chunk)
+        return hasher.hexdigest()
+
+    def digest_whole(self) -> str:
+        return self.digest_range(0, self.path.stat().st_size)
+
+
+def safe_basename(path: Path) -> str:
+    return path.name or str(path)
+
+
+def load_config(path: Path) -> list[dict[str, Any]]:
+    try:
+        data = path.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise PreflightError("missingConfig", "找不到 patches.json", details={"path": str(path)}) from exc
+    except UnicodeDecodeError as exc:
+        raise PreflightError("invalidConfig", "patches.json 不是合法 UTF-8 文本", details={"path": str(path)}) from exc
+    try:
+        value = json.loads(data)
+    except json.JSONDecodeError as exc:
+        raise PreflightError("invalidConfig", "patches.json 不是合法 JSON", details={"path": str(path)}) from exc
+    if not isinstance(value, list):
+        raise PreflightError("invalidConfig", "patches.json 顶层必须是数组", details={"path": str(path)})
+    return value
+
+
+def _path_is_inside(candidate: Path, root: Path) -> bool:
+    try:
+        candidate.resolve(strict=True).relative_to(root.resolve(strict=True))
+        return True
+    except Exception:
+        return False
+
+
+def _validate_target_entries(entries: Any, *, config_path: Path, build_version: str, target_index: int) -> list[dict[str, Any]]:
+    if not isinstance(entries, list) or not entries:
+        raise PreflightError(
+            "invalidConfig",
+            "patches.json 里的 entries 必须是非空数组",
+            details={"path": str(config_path), "buildVersion": build_version, "targetIndex": target_index},
+        )
+
+    normalized: list[dict[str, Any]] = []
+    for entry_index, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            raise PreflightError(
+                "invalidConfig",
+                "patches.json 里的 entry 必须是对象",
+                details={"path": str(config_path), "buildVersion": build_version, "targetIndex": target_index, "entryIndex": entry_index},
+            )
+        arch = entry.get("arch")
+        addr = entry.get("addr")
+        expected = entry.get("expected")
+        asm = entry.get("asm")
+        if not isinstance(arch, str) or not arch:
+            raise PreflightError(
+                "invalidConfig",
+                "patches.json 里的 entry 缺少 arch",
+                details={"path": str(config_path), "buildVersion": build_version, "targetIndex": target_index, "entryIndex": entry_index},
+            )
+        if not isinstance(addr, str) or not addr:
+            raise PreflightError(
+                "invalidConfig",
+                "patches.json 里的 entry 缺少 addr",
+                details={"path": str(config_path), "buildVersion": build_version, "targetIndex": target_index, "entryIndex": entry_index, "arch": arch},
+            )
+        if not isinstance(asm, str) or not asm:
+            raise PreflightError(
+                "invalidConfig",
+                "patches.json 里的 entry 缺少 asm",
+                details={"path": str(config_path), "buildVersion": build_version, "targetIndex": target_index, "entryIndex": entry_index, "arch": arch},
+            )
+        if not isinstance(expected, (str, list)) or (isinstance(expected, list) and not all(isinstance(item, str) for item in expected)):
+            raise PreflightError(
+                "invalidConfig",
+                "patches.json 里的 entry expected 格式不合法",
+                details={"path": str(config_path), "buildVersion": build_version, "targetIndex": target_index, "entryIndex": entry_index, "arch": arch},
+            )
+        normalized.append(entry)
+    return normalized
+
+
+def read_app_info(app_path: Path) -> AppInfo:
+    if not app_path.exists():
+        raise PreflightError("missingApp", "找不到 app bundle", details={"path": str(app_path)})
+    if not app_path.is_dir():
+        raise PreflightError("missingApp", "app 路径不是目录", details={"path": str(app_path)})
+
+    info_path = app_path / "Contents" / "Info.plist"
+    if not info_path.exists():
+        raise PreflightError("missingInfoPlist", "找不到 Info.plist", details={"path": str(info_path)})
+    if not info_path.is_file():
+        raise PreflightError("missingInfoPlist", "找不到 Info.plist", details={"path": str(info_path)})
+    if not _path_is_inside(info_path, app_path):
+        raise PreflightError("pathEscape", "Info.plist 指向 bundle 外部")
+    try:
+        with info_path.open("rb") as fh:
+            plist = plistlib.load(fh)
+    except Exception as exc:  # pragma: no cover - defensive, surfaced in tests via message
+        raise PreflightError("invalidInfoPlist", "Info.plist 不是合法 plist", details={"path": str(info_path)}) from exc
+    if not isinstance(plist, dict):
+        raise PreflightError("invalidInfoPlist", "Info.plist 内容不是字典", details={"path": str(info_path)})
+
+    required = {
+        "CFBundleExecutable": "executable",
+        "CFBundleShortVersionString": "marketingVersion",
+        "CFBundleVersion": "buildVersion",
+        "CFBundleIdentifier": "bundleIdentifier",
+    }
+    extracted: dict[str, str] = {}
+    for plist_key, report_key in required.items():
+        value = plist.get(plist_key)
+        if not isinstance(value, str) or not value:
+            raise PreflightError("missingInfoField", f"Info.plist 缺少 {plist_key}", details={"path": str(info_path), "key": plist_key})
+        extracted[report_key] = value
+
+    binary_path = app_path / DEFAULT_BINARY_RELATIVE_PATH
+    if not binary_path.exists():
+        raise PreflightError("missingBinary", "找不到 bundled wechat.dylib", details={"path": str(binary_path)})
+    if not binary_path.is_file():
+        raise PreflightError("missingBinary", "bundled wechat.dylib 不是文件", details={"path": str(binary_path)})
+    if not _path_is_inside(binary_path, app_path):
+        raise PreflightError("pathEscape", "bundled wechat.dylib 指向 bundle 外部")
+
+    return AppInfo(
+        app_path=app_path,
+        bundle_identifier=extracted["bundleIdentifier"],
+        marketing_version=extracted["marketingVersion"],
+        build_version=extracted["buildVersion"],
+        executable_name=extracted["executable"],
+        binary_path=binary_path,
+    )
+
+
+def analyze_binary(path: Path) -> BinaryReport:
+    view = ReadOnlyFile(path)
+    try:
+        file_size = path.stat().st_size
+        whole_sha = view.digest_whole()
+        magic = struct.unpack(">I", view.read_at(0, 4))[0]
+        if magic == FAT_MAGIC:
+            slices = _analyze_fat(view, path, file_size, is_64_bit=False)
+            kind = "fat32"
+        elif magic == FAT_MAGIC_64:
+            slices = _analyze_fat(view, path, file_size, is_64_bit=True)
+            kind = "fat64"
+        elif struct.unpack("<I", view.read_at(0, 4))[0] == MH_MAGIC_64:
+            slices = [_analyze_thin_slice(view, path, 0, file_size)]
+            kind = f"thin-{slices[0].arch}"
+        else:
+            raise PreflightError("unsupportedMachO", "不支持的 Mach-O 文件格式", details={"path": str(path)})
+    finally:
+        view.close()
+
+    x86_hash = next((slice_.sha256 for slice_ in slices if slice_.arch == "x86_64"), None)
+    return BinaryReport(
+        path=str(path),
+        kind=kind,
+        sha256=whole_sha,
+        x86_64_slice_sha256=x86_hash,
+        slices=slices,
+    )
+
+
+def _analyze_fat(view: ReadOnlyFile, path: Path, file_size: int, *, is_64_bit: bool) -> list[MachOSlice]:
+    if file_size < (8 + (32 if is_64_bit else 20)):
+        raise PreflightError("invalidFat", "fat 头部过短", details={"path": str(path)})
+    nfat = struct.unpack(">I", view.read_at(4, 4))[0]
+    if nfat <= 0:
+        raise PreflightError("invalidFat", "fat Mach-O 里没有切片", details={"path": str(path), "nfat": nfat})
+    entry_size = 32 if is_64_bit else 20
+    table_size = 8 + nfat * entry_size
+    if table_size > file_size:
+        raise PreflightError("invalidFat", "fat 头部超出文件边界", details={"path": str(path)})
+
+    slice_specs: list[dict[str, int]] = []
+    seen_arches: set[str] = set()
+    occupied_ranges: list[tuple[int, int]] = []
+    for index in range(nfat):
+        entry_offset = 8 + index * entry_size
+        entry = view.read_at(entry_offset, entry_size)
+        if is_64_bit:
+            cputype, _cpusubtype, slice_offset, slice_size, _align, _reserved = struct.unpack(">IIQQII", entry)
+        else:
+            cputype, _cpusubtype, slice_offset32, slice_size32, _align = struct.unpack(">IIIII", entry)
+            slice_offset = slice_offset32
+            slice_size = slice_size32
+        if slice_size < 32:
+            raise PreflightError(
+                "invalidFatSlice",
+                "fat 切片过短",
+                details={"path": str(path), "sliceIndex": index, "offset": slice_offset, "size": slice_size},
+            )
+        if slice_offset < table_size:
+            raise PreflightError(
+                "invalidFatSlice",
+                "fat 切片落在 fat 头部或 table 覆盖范围内",
+                details={"path": str(path), "sliceIndex": index, "offset": slice_offset, "tableSize": table_size},
+            )
+        if slice_offset + slice_size > file_size:
+            raise PreflightError(
+                "invalidFatSlice",
+                "fat 切片超出文件边界",
+                details={"path": str(path), "sliceIndex": index, "offset": slice_offset, "size": slice_size},
+            )
+        arch = ARCH_BY_CPU_TYPE.get(cputype, f"cpu-0x{cputype:x}")
+        if arch in seen_arches:
+            raise PreflightError(
+                "duplicateSliceArch",
+                "fat Mach-O 包含重复架构切片",
+                details={"path": str(path), "arch": arch, "sliceIndex": index},
+            )
+        for start, end in occupied_ranges:
+            if not (slice_offset + slice_size <= start or slice_offset >= end):
+                raise PreflightError(
+                    "overlappingSlice",
+                    "fat Mach-O 切片范围重叠",
+                    details={"path": str(path), "arch": arch, "sliceIndex": index},
+                )
+        seen_arches.add(arch)
+        occupied_ranges.append((slice_offset, slice_offset + slice_size))
+        slice_specs.append({"offset": slice_offset, "size": slice_size, "cputype": cputype})
+
+    slices: list[MachOSlice] = []
+    for spec in slice_specs:
+        slices.append(_analyze_thin_slice(view, path, spec["offset"], spec["size"], cputype=spec["cputype"]))
+    return slices
+
+
+def _analyze_thin_slice(
+    view: ReadOnlyFile,
+    path: Path,
+    offset: int,
+    size: int,
+    *,
+    cputype: int | None = None,
+) -> MachOSlice:
+    header = view.read_at(offset, 32)
+    magic, header_cpu_type, _cpusubtype, _filetype, ncmds, sizeofcmds, _flags, _reserved = struct.unpack("<IIIIIIII", header)
+    if magic != MH_MAGIC_64:
+        raise PreflightError("invalidMachO", "切片不是薄 Mach-O 64-bit", details={"path": str(path), "offset": offset})
+
+    if cputype is None:
+        cputype = header_cpu_type
+    if header_cpu_type != cputype:
+        raise PreflightError("cpuMismatch", "fat 目录项与切片头 CPU type 不一致", details={"path": str(path), "offset": offset})
+    arch = ARCH_BY_CPU_TYPE.get(cputype)
+    if arch is None:
+        arch = f"cpu-0x{cputype:x}"
+
+    if sizeofcmds + 32 > size:
+        raise PreflightError(
+            "invalidMachO",
+            "Mach-O load commands 超出切片边界",
+            details={"path": str(path), "offset": offset, "sizeofcmds": sizeofcmds, "size": size},
+        )
+
+    commands = view.read_at(offset + 32, sizeofcmds)
+    cursor = 0
+    segments: list[dict[str, Any]] = []
+    for _ in range(ncmds):
+        if cursor + 8 > len(commands):
+            raise PreflightError("invalidMachO", "Mach-O load command 被截断", details={"path": str(path), "offset": offset})
+        cmd, cmdsize = struct.unpack_from("<II", commands, cursor)
+        if cmdsize < 8 or cursor + cmdsize > len(commands):
+            raise PreflightError("invalidMachO", "Mach-O load command 超出边界", details={"path": str(path), "offset": offset})
+        command = commands[cursor:cursor + cmdsize]
+        if cmd == LC_SEGMENT_64:
+            if cmdsize < 72:
+                raise PreflightError("invalidMachO", "LC_SEGMENT_64 长度不足", details={"path": str(path), "offset": offset})
+            segname = command[8:24].split(b"\0", 1)[0].decode("ascii", errors="replace")
+            vmaddr, vmsize, fileoff, filesize = struct.unpack_from("<QQQQ", command, 24)
+            if fileoff + filesize > size:
+                raise PreflightError(
+                    "invalidSegment",
+                    "Mach-O segment 超出切片边界",
+                    details={"path": str(path), "offset": offset, "segment": segname, "fileoff": fileoff, "filesize": filesize, "size": size},
+                )
+            segments.append(
+                {
+                    "name": segname,
+                    "vmaddr": f"0x{vmaddr:x}",
+                    "vmsize": f"0x{vmsize:x}",
+                    "fileoff": f"0x{fileoff:x}",
+                    "filesize": f"0x{filesize:x}",
+                }
+            )
+        cursor += cmdsize
+
+    if cursor != len(commands):
+        raise PreflightError("invalidMachO", "Mach-O load commands 未完全消费", details={"path": str(path), "offset": offset})
+
+    sha = view.digest_range(offset, size)
+    return MachOSlice(arch=arch, offset=offset, size=size, sha256=sha, segments=segments)
+
+
+def load_catalog_report(config_path: Path, build_version: str) -> CatalogReport:
+    configs = load_config(config_path)
+    matched_items: list[dict[str, Any]] = []
+    for index, item in enumerate(configs):
+        if not isinstance(item, dict):
+            raise PreflightError("invalidConfig", "patches.json 顶层条目必须是对象", details={"index": index})
+        if item.get("version") == build_version:
+            matched_items.append(item)
+    if len(matched_items) > 1:
+        raise PreflightError("invalidConfig", "patches.json 里 buildVersion 重复", details={"path": str(config_path), "buildVersion": build_version})
+    if not matched_items:
+        targets: list[ConfigTargetReport] = []
+        return CatalogReport(
+            path=str(config_path),
+            build_version=build_version,
+            build_matched=False,
+            target_count=0,
+            intel_covered=False,
+            targets=targets,
+        )
+
+    matched = matched_items[0]
+    raw_targets = matched.get("targets")
+    if not isinstance(raw_targets, list):
+        raise PreflightError("invalidConfig", "patches.json 里 targets 必须是数组", details={"path": str(config_path), "buildVersion": build_version})
+
+    targets: list[ConfigTargetReport] = []
+    for target_index, target in enumerate(raw_targets):
+        if not isinstance(target, dict):
+            raise PreflightError("invalidConfig", "patches.json 里的 target 必须是对象", details={"index": target_index, "buildVersion": build_version})
+        identifier = target.get("identifier")
+        entries = _validate_target_entries(target.get("entries"), config_path=config_path, build_version=build_version, target_index=target_index)
+        if not isinstance(identifier, str) or not identifier:
+            raise PreflightError("invalidConfig", "patches.json 里的 target 缺少 identifier", details={"index": target_index, "buildVersion": build_version})
+        arches = sorted({entry["arch"] for entry in entries})
+        intel_covered = any(entry["arch"] == "x86_64" for entry in entries)
+        targets.append(
+            ConfigTargetReport(
+                identifier=identifier,
+                feature=FEATURE_BY_IDENTIFIER.get(identifier, identifier),
+                arches=arches,
+                entry_count=len(entries),
+                intel_covered=intel_covered,
+            )
+        )
+
+    return CatalogReport(
+        path=str(config_path),
+        build_version=build_version,
+        build_matched=True,
+        target_count=len(targets),
+        intel_covered=any(target.intel_covered for target in targets),
+        targets=targets,
+    )
+
+
+def build_report(app_path: Path, config_path: Path) -> Report:
+    app = read_app_info(app_path)
+    binary = analyze_binary(app.binary_path)
+    catalog = load_catalog_report(config_path, app.build_version)
+    x86_note = "有 x86_64 slice" if binary.x86_64_slice_sha256 else "无 x86_64 slice"
+    intel_note = "有 Intel catalog 覆盖" if catalog.intel_covered else "catalog 未提供 x86_64 覆盖"
+    swift_probe = _probe_command(["swift", "--version"])
+    sdk_version_probe = _probe_command(["xcrun", "--sdk", "macosx", "--show-sdk-version"])
+    sdk_platform_probe = _probe_command(["xcrun", "--sdk", "macosx", "--show-sdk-platform-path"], redact_output=True)
+    host = HostInfo(
+        python_version=sys.version.split()[0],
+        implementation=sys.implementation.name,
+        platform=sys.platform,
+        executable=sys.executable,
+        machine=platform.machine() or "unknown",
+        macos_version=platform.mac_ver()[0] or "unknown",
+        swift_probe=swift_probe,
+        macos_sdk_version_probe=sdk_version_probe,
+        macos_sdk_platform_probe=sdk_platform_probe,
+    )
+    summary = (
+        f"{safe_basename(app.app_path)} {app.marketing_version} ({app.build_version})："
+        f"binary={binary.kind}，{x86_note}；"
+        f"catalog={'命中' if catalog.build_matched else '未命中'}，"
+        f"targets={catalog.target_count}，{intel_note}；"
+        f"host={host.machine} / {host.macos_version} / Python {host.python_version} / "
+        f"Swift {host.swift_probe.status} / SDK {host.macos_sdk_version_probe.detail} / "
+        f"SDK平台路径 probe {host.macos_sdk_platform_probe.status}；"
+        f"非 Swift CLI dry-run。"
+    )
+    return Report(JSON_SCHEMA_VERSION, app, binary, catalog, host, summary)
+
+
+def _probe_command(command: list[str], *, redact_output: bool = False) -> ProbeResult:
+    try:
+        completed = subprocess.run(
+            command,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            timeout=10,
+        )
+    except FileNotFoundError:
+        return ProbeResult("unavailable", "command not found", exit_code=127)
+    except subprocess.TimeoutExpired:
+        return ProbeResult("timeout", "timeout >=10s", exit_code=124)
+    except subprocess.CalledProcessError as exc:
+        output_text = getattr(exc, "stdout", None) or getattr(exc, "output", None) or ""
+        output = output_text.strip().splitlines()
+        detail = _redact_probe_text(output[0] if output else "")
+        if not detail:
+            detail = "probe failed"
+        return ProbeResult("error", detail, exit_code=exc.returncode)
+    output = completed.stdout.strip().splitlines()
+    if redact_output:
+        return ProbeResult("ok", "redacted", exit_code=completed.returncode)
+    return ProbeResult("ok", _redact_probe_text(output[0] if output else "unavailable"), exit_code=completed.returncode)
+
+
+def _redact_probe_text(text: str) -> str:
+    if not text:
+        return text
+    redacted = text
+    for token in _extract_absolute_paths(text):
+        redacted = redacted.replace(token, "[redacted]")
+    return redacted
+
+
+def _extract_absolute_paths(text: str) -> list[str]:
+    return re.findall(r"/[^\s,;:)]+", text)
+
+
+def render_summary(report: Report) -> str:
+    lines = [
+        f"应用：{safe_basename(report.app.app_path)} / 构建 {report.app.build_version} / 版本 {report.app.marketing_version}",
+        f"二进制：{Path(report.binary.path).name} / {report.binary.kind} / whole SHA256 {report.binary.sha256}",
+    ]
+    if report.binary.x86_64_slice_sha256:
+        lines.append(f"x86_64 slice SHA256：{report.binary.x86_64_slice_sha256}")
+    else:
+        lines.append("x86_64 slice SHA256：未发现 x86_64 slice")
+    lines.append(
+        f"catalog：{'命中' if report.catalog.build_matched else '未命中'} build {report.catalog.build_version}，"
+        f"targets {report.catalog.target_count}，Intel 覆盖 {'是' if report.catalog.intel_covered else '否'}"
+    )
+    if report.catalog.targets:
+        feature_text = ", ".join(f"{item.feature}:{'/'.join(item.arches) or '-'}" for item in report.catalog.targets)
+        lines.append(f"features：{feature_text}")
+    lines.append(
+        f"toolchain：CPU {report.host.machine}，macOS {report.host.macos_version}，"
+        f"Python {report.host.python_version}，Swift probe {report.host.swift_probe.status}，"
+        f"SDK 版本 {report.host.macos_sdk_version_probe.detail} (exitCode={report.host.macos_sdk_version_probe.exit_code})，"
+        f"SDK 平台路径 probe {report.host.macos_sdk_platform_probe.status} (exitCode={report.host.macos_sdk_platform_probe.exit_code})"
+    )
+    lines.append(
+        "结论：这是只读目录预检，非 Swift CLI dry-run，不代表补丁已安装或真实 Intel 实机已验证。"
+    )
+    return "\n".join(lines)
+
+
+def emit_json(report: Report) -> None:
+    print(json.dumps(report.to_jsonable(), ensure_ascii=False, indent=2, sort_keys=True))
+
+
+def emit_error(error: PreflightError) -> None:
+    print(json.dumps({"schemaVersion": JSON_SCHEMA_VERSION, "error": error.to_payload()}, ensure_ascii=False, indent=2, sort_keys=True))
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--app", default=DEFAULT_APP_PATH, help="要检查的 WeChat.app 路径")
+    parser.add_argument("--config", default=DEFAULT_CONFIG_PATH, help="patches.json 路径")
+    parser.add_argument("--summary", action="store_true", help="输出适合粘贴 issue 的中文摘要")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        report = build_report(Path(args.app), Path(args.config))
+    except PreflightError as error:
+        emit_error(error)
+        return 1
+    except OSError as error:
+        emit_error(PreflightError("osError", error.__class__.__name__))
+        return 1
+
+    if args.summary:
+        print(render_summary(report))
+    else:
+        emit_json(report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Scripts/tests/test_intel_preflight.py
+++ b/Scripts/tests/test_intel_preflight.py
@@ -1,0 +1,430 @@
+import hashlib
+import importlib.util
+import json
+import plistlib
+import struct
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = ROOT / "Scripts" / "intel-preflight.py"
+
+spec = importlib.util.spec_from_file_location("intel_preflight", SCRIPT_PATH)
+assert spec is not None and spec.loader is not None
+intel_preflight = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = intel_preflight
+spec.loader.exec_module(intel_preflight)
+
+
+class IntelPreflightTests(unittest.TestCase):
+    def test_thin_binary_report_and_summary(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            app_path = self._make_app_bundle(root, build_version="269624")
+            slice_bytes = self._make_thin_macho(0x0100000C, payload_seed=0x11)
+            binary_path = app_path / "Contents" / "Resources" / "wechat.dylib"
+            binary_path.write_bytes(slice_bytes)
+            config_path = self._write_config(root, build_version="269624")
+
+            report = intel_preflight.build_report(app_path, config_path)
+
+            self.assertEqual(report.binary.kind, "thin-arm64")
+            self.assertEqual(report.binary.sha256, hashlib.sha256(slice_bytes).hexdigest())
+            self.assertEqual(report.binary.x86_64_slice_sha256, None)
+            self.assertEqual(report.catalog.build_matched, True)
+            self.assertEqual(report.catalog.target_count, 2)
+            self.assertEqual(report.catalog.intel_covered, True)
+            self.assertEqual(report.catalog.targets[0].feature, "silent")
+            self.assertEqual(report.catalog.targets[0].arches, ["arm64"])
+            self.assertEqual(report.catalog.targets[1].feature, "block-update")
+            self.assertEqual(report.catalog.targets[1].arches, ["x86_64"])
+            self.assertIn("有 Intel catalog 覆盖", report.summary)
+            self.assertIn("非 Swift CLI dry-run", report.summary)
+            summary = intel_preflight.render_summary(report)
+            self.assertIn("应用：WeChat.app / 构建 269624 / 版本 4.1.13.56", summary)
+            self.assertIn("x86_64 slice SHA256：未发现 x86_64 slice", summary)
+            self.assertIn("catalog：命中 build 269624，targets 2，Intel 覆盖 是", summary)
+            self.assertIn("非 Swift CLI dry-run", summary)
+            self.assertEqual(report.to_jsonable()["host"]["swiftProbe"]["status"], "ok")
+            self.assertEqual(report.to_jsonable()["limitations"], ["只读目录预检", "不写入、不安装、不签名、不联网", "非 Swift CLI dry-run", "不代表真实 Intel 实机已验证"])
+            self.assertEqual(report.to_jsonable()["app"]["path"], "WeChat.app")
+            self.assertEqual(report.to_jsonable()["binary"]["path"], "wechat.dylib")
+            self.assertEqual(report.to_jsonable()["catalog"]["path"], "patches.json")
+
+            encoded = report.to_jsonable()
+            self.assertEqual(encoded["schemaVersion"], 1)
+            self.assertEqual(encoded["binary"]["sha256"], hashlib.sha256(slice_bytes).hexdigest())
+
+    def test_fat32_binary_reports_x86_slice_hash(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            app_path = self._make_app_bundle(root, build_version="269624")
+            x86_slice = self._make_thin_macho(0x01000007, payload_seed=0x22)
+            arm_slice = self._make_thin_macho(0x0100000C, payload_seed=0x33)
+            fat = self._make_fat_binary([(0x01000007, x86_slice), (0x0100000C, arm_slice)], fat64=False)
+            binary_path = app_path / "Contents" / "Resources" / "wechat.dylib"
+            binary_path.write_bytes(fat)
+            config_path = self._write_config(root, build_version="269624")
+
+            report = intel_preflight.build_report(app_path, config_path)
+
+            self.assertEqual(report.binary.kind, "fat32")
+            self.assertEqual(report.binary.sha256, hashlib.sha256(fat).hexdigest())
+            self.assertEqual(report.binary.x86_64_slice_sha256, hashlib.sha256(x86_slice).hexdigest())
+            self.assertEqual([slice_.arch for slice_ in report.binary.slices], ["x86_64", "arm64"])
+            self.assertEqual(report.binary.slices[0].offset, 256)
+            self.assertEqual(report.binary.slices[1].offset, 1024)
+
+    def test_fat64_binary_reports_x86_slice_hash(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            app_path = self._make_app_bundle(root, build_version="269624")
+            x86_slice = self._make_thin_macho(0x01000007, payload_seed=0x44)
+            arm_slice = self._make_thin_macho(0x0100000C, payload_seed=0x55)
+            fat = self._make_fat_binary([(0x01000007, x86_slice), (0x0100000C, arm_slice)], fat64=True)
+            binary_path = app_path / "Contents" / "Resources" / "wechat.dylib"
+            binary_path.write_bytes(fat)
+            config_path = self._write_config(root, build_version="269624")
+
+            report = intel_preflight.build_report(app_path, config_path)
+
+            self.assertEqual(report.binary.kind, "fat64")
+            self.assertEqual(report.binary.x86_64_slice_sha256, hashlib.sha256(x86_slice).hexdigest())
+            self.assertEqual([slice_.arch for slice_ in report.binary.slices], ["x86_64", "arm64"])
+            self.assertEqual(report.catalog.targets[0].entry_count, 1)
+
+    def test_missing_app_and_missing_binary_are_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            config_path = self._write_config(root, build_version="269624")
+            with self.assertRaises(intel_preflight.PreflightError) as ctx:
+                intel_preflight.build_report(root / "Nope.app", config_path)
+            self.assertEqual(ctx.exception.kind, "missingApp")
+
+            app_path = self._make_app_bundle(root, build_version="269624")
+            (app_path / "Contents" / "Resources" / "wechat.dylib").unlink()
+            with self.assertRaises(intel_preflight.PreflightError) as ctx2:
+                intel_preflight.build_report(app_path, config_path)
+            self.assertEqual(ctx2.exception.kind, "missingBinary")
+
+    def test_missing_info_plist_is_reported_before_containment(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            app_path = self._make_app_bundle(root, build_version="269624")
+            info_path = app_path / "Contents" / "Info.plist"
+            info_path.unlink()
+            config_path = self._write_config(root, build_version="269624")
+
+            with self.assertRaises(intel_preflight.PreflightError) as ctx:
+                intel_preflight.build_report(app_path, config_path)
+            self.assertEqual(ctx.exception.kind, "missingInfoPlist")
+
+    def test_bundle_symlink_escape_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            app_path = self._make_app_bundle(root, build_version="269624")
+            outside = root / "outside.dylib"
+            outside.write_bytes(self._make_thin_macho(0x0100000C, payload_seed=0x77))
+            escaped = app_path / "Contents" / "Resources" / "wechat.dylib"
+            if escaped.exists() or escaped.is_symlink():
+                escaped.unlink()
+            escaped.symlink_to(outside)
+            config_path = self._write_config(root, build_version="269624")
+
+            with self.assertRaises(intel_preflight.PreflightError) as ctx:
+                intel_preflight.build_report(app_path, config_path)
+            self.assertEqual(ctx.exception.kind, "pathEscape")
+
+    def test_config_validation_rejects_non_objects_and_bad_entries(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            app_path = self._make_app_bundle(root, build_version="269624")
+            (app_path / "Contents" / "Resources" / "wechat.dylib").write_bytes(self._make_thin_macho(0x0100000C, payload_seed=0x11))
+
+            bad_root = root / "bad.json"
+            bad_root.write_text(json.dumps([1, {"version": "269624", "targets": ["oops"]}], ensure_ascii=False), encoding="utf-8")
+            with self.assertRaises(intel_preflight.PreflightError) as ctx:
+                intel_preflight.build_report(app_path, bad_root)
+            self.assertEqual(ctx.exception.kind, "invalidConfig")
+
+            bad_target = root / "bad-target.json"
+            bad_target.write_text(json.dumps([
+                {"version": "269624", "targets": [{"entries": []}]}
+            ], ensure_ascii=False), encoding="utf-8")
+            with self.assertRaises(intel_preflight.PreflightError) as ctx2:
+                intel_preflight.build_report(app_path, bad_target)
+            self.assertEqual(ctx2.exception.kind, "invalidConfig")
+
+    def test_catalog_loads_all_repository_builds_with_repeated_arch_entries(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            config_path = ROOT / "patches.json"
+            versions = [item["version"] for item in json.loads(config_path.read_text(encoding="utf-8"))]
+            app_path = self._make_app_bundle(root, build_version=versions[0])
+            (app_path / "Contents" / "Resources" / "wechat.dylib").write_bytes(self._make_thin_macho(0x0100000C, payload_seed=0x12))
+
+            repeated = intel_preflight._validate_target_entries(  # type: ignore[attr-defined]
+                [
+                    {"arch": "arm64", "addr": "10", "expected": "11", "asm": "22"},
+                    {"arch": "arm64", "addr": "20", "expected": "33", "asm": "44"},
+                ],
+                config_path=config_path,
+                build_version=versions[0],
+                target_index=0,
+            )
+            self.assertEqual(len(repeated), 2)
+
+            for version in versions:
+                report = intel_preflight.load_catalog_report(config_path, version)
+                self.assertTrue(report.build_matched)
+                self.assertGreater(report.target_count, 0)
+                self.assertTrue(any(target.entry_count >= 1 for target in report.targets))
+
+    def test_fat_binary_rejects_duplicate_overlap_and_cpu_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            app_path = self._make_app_bundle(root, build_version="269624")
+            x86_slice = self._make_thin_macho(0x01000007, payload_seed=0x22)
+            arm_slice = self._make_thin_macho(0x0100000C, payload_seed=0x33)
+            config_path = self._write_config(root, build_version="269624")
+
+            duplicate = self._make_fat_binary([(0x01000007, x86_slice), (0x01000007, x86_slice)], fat64=False)
+            (app_path / "Contents" / "Resources" / "wechat.dylib").write_bytes(duplicate)
+            with self.assertRaises(intel_preflight.PreflightError) as ctx:
+                intel_preflight.build_report(app_path, config_path)
+            self.assertEqual(ctx.exception.kind, "duplicateSliceArch")
+
+            overlap = self._make_fat_binary([(0x01000007, x86_slice), (0x0100000C, arm_slice)], fat64=False)
+            overlap = bytearray(overlap)
+            # Force the second slice to overlap the first one.
+            struct.pack_into(">I", overlap, 8 + 20 + 8, 300)
+            (app_path / "Contents" / "Resources" / "wechat.dylib").write_bytes(bytes(overlap))
+            with self.assertRaises(intel_preflight.PreflightError) as ctx2:
+                intel_preflight.build_report(app_path, config_path)
+            self.assertEqual(ctx2.exception.kind, "overlappingSlice")
+
+            mismatch = bytearray(self._make_fat_binary([(0x01000007, x86_slice)], fat64=False))
+            struct.pack_into("<I", mismatch, 256 + 4, 0x0100000C)
+            (app_path / "Contents" / "Resources" / "wechat.dylib").write_bytes(bytes(mismatch))
+            with self.assertRaises(intel_preflight.PreflightError) as ctx3:
+                intel_preflight.build_report(app_path, config_path)
+            self.assertEqual(ctx3.exception.kind, "cpuMismatch")
+
+    def test_fat_binary_rejects_slice_overlapping_header_or_table(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            app_path = self._make_app_bundle(root, build_version="269624")
+            config_path = self._write_config(root, build_version="269624")
+            malformed = self._make_fat_binary_with_offsets(
+                [(0x01000007, self._make_thin_macho(0x01000007, payload_seed=0x88), 24)],
+                fat64=False,
+            )
+            (app_path / "Contents" / "Resources" / "wechat.dylib").write_bytes(malformed)
+
+            with self.assertRaises(intel_preflight.PreflightError) as ctx:
+                intel_preflight.build_report(app_path, config_path)
+            self.assertEqual(ctx.exception.kind, "invalidFatSlice")
+            self.assertIn("table", ctx.exception.message)
+
+    def test_fat_binary_rejects_zero_slices(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            app_path = self._make_app_bundle(root, build_version="269624")
+            config_path = self._write_config(root, build_version="269624")
+            malformed = bytearray(struct.pack(">II", 0xCAFEBABE, 0))
+            malformed.extend(b"\0" * 64)
+            (app_path / "Contents" / "Resources" / "wechat.dylib").write_bytes(bytes(malformed))
+
+            with self.assertRaises(intel_preflight.PreflightError) as ctx:
+                intel_preflight.build_report(app_path, config_path)
+            self.assertEqual(ctx.exception.kind, "invalidFat")
+            self.assertIn("没有切片", ctx.exception.message)
+
+    def test_duplicate_build_version_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            app_path = self._make_app_bundle(root, build_version="269624")
+            (app_path / "Contents" / "Resources" / "wechat.dylib").write_bytes(self._make_thin_macho(0x0100000C, payload_seed=0x66))
+            config_path = root / "patches.json"
+            config_path.write_text(
+                json.dumps(
+                    [
+                        {
+                            "version": "269624",
+                            "targets": [
+                                {"identifier": "revoke", "entries": [{"arch": "arm64", "addr": "10", "expected": "11", "asm": "22"}]}
+                            ],
+                        },
+                        {
+                            "version": "269624",
+                            "targets": [
+                                {"identifier": "update", "entries": [{"arch": "x86_64", "addr": "20", "expected": "33", "asm": "44"}]}
+                            ],
+                        },
+                    ],
+                    ensure_ascii=False,
+                    indent=2,
+                ),
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(intel_preflight.PreflightError) as ctx:
+                intel_preflight.load_catalog_report(config_path, "269624")
+            self.assertEqual(ctx.exception.kind, "invalidConfig")
+            self.assertIn("重复", ctx.exception.message)
+
+    def test_unsupported_macho_and_json_output(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            app_path = self._make_app_bundle(root, build_version="269624")
+            binary_path = app_path / "Contents" / "Resources" / "wechat.dylib"
+            binary_path.write_bytes(b"not mach-o")
+            config_path = self._write_config(root, build_version="269624")
+
+            with self.assertRaises(intel_preflight.PreflightError) as ctx:
+                intel_preflight.analyze_binary(binary_path)
+            self.assertEqual(ctx.exception.kind, "unsupportedMachO")
+
+            binary_path.write_bytes(self._make_thin_macho(0x0100000C, payload_seed=0x66))
+            report = intel_preflight.build_report(app_path, config_path)
+            payload = json.dumps(report.to_jsonable(), ensure_ascii=False, sort_keys=True)
+            parsed = json.loads(payload)
+            self.assertEqual(parsed["schemaVersion"], 1)
+            self.assertEqual(parsed["app"]["bundleIdentifier"], "com.tencent.xinWeChat")
+            self.assertEqual(parsed["binary"]["kind"], "thin-arm64")
+
+    def test_main_converts_oserror_to_json_error(self) -> None:
+        original = intel_preflight.build_report
+        try:
+            def boom(_app_path: Path, _config_path: Path):
+                raise OSError("boom")
+            intel_preflight.build_report = boom  # type: ignore[assignment]
+            exit_code = intel_preflight.main(["--app", "/tmp/WeChat.app", "--config", "/tmp/patches.json"])
+            self.assertEqual(exit_code, 1)
+        finally:
+            intel_preflight.build_report = original  # type: ignore[assignment]
+
+    def test_probe_command_redacts_paths_and_captures_exit_code(self) -> None:
+        original = intel_preflight.subprocess.run
+
+        class Completed:
+            def __init__(self, stdout: str, returncode: int):
+                self.stdout = stdout
+                self.returncode = returncode
+
+        try:
+            def fake_run_failure(*_args, **_kwargs):
+                raise intel_preflight.subprocess.CalledProcessError(
+                    2,
+                    ["xcrun"],
+                    output="error loading /Users/PRIVATE_SENTINEL/toolchain\n",
+                )
+
+            intel_preflight.subprocess.run = fake_run_failure  # type: ignore[assignment]
+            failure = intel_preflight._probe_command(["xcrun"], redact_output=False)  # type: ignore[attr-defined]
+            self.assertEqual(failure.status, "error")
+            self.assertEqual(failure.exit_code, 2)
+            self.assertNotIn("/Users/PRIVATE_SENTINEL/toolchain", failure.detail)
+            self.assertIn("[redacted]", failure.detail)
+
+            def fake_run_success(*_args, **_kwargs):
+                return Completed("toolchain at /Users/PRIVATE_SENTINEL/toolchain\n", 0)
+
+            intel_preflight.subprocess.run = fake_run_success  # type: ignore[assignment]
+            success = intel_preflight._probe_command(["swift"], redact_output=False)  # type: ignore[attr-defined]
+            self.assertEqual(success.status, "ok")
+            self.assertEqual(success.exit_code, 0)
+            self.assertNotIn("/Users/PRIVATE_SENTINEL/toolchain", success.detail)
+            self.assertIn("[redacted]", success.detail)
+        finally:
+            intel_preflight.subprocess.run = original  # type: ignore[assignment]
+
+    def _make_app_bundle(self, root: Path, *, build_version: str) -> Path:
+        app_path = root / "WeChat.app"
+        info_path = app_path / "Contents" / "Info.plist"
+        binary_dir = app_path / "Contents" / "Resources"
+        binary_dir.mkdir(parents=True, exist_ok=True)
+        info_path.parent.mkdir(parents=True, exist_ok=True)
+        plist = {
+            "CFBundleExecutable": "WeChat",
+            "CFBundleShortVersionString": "4.1.13.56",
+            "CFBundleVersion": build_version,
+            "CFBundleIdentifier": "com.tencent.xinWeChat",
+        }
+        with info_path.open("wb") as fh:
+            plistlib.dump(plist, fh)
+        (binary_dir / "wechat.dylib").write_bytes(self._make_thin_macho(0x0100000C, payload_seed=0x10))
+        return app_path
+
+    def _write_config(self, root: Path, *, build_version: str) -> Path:
+        config = [
+            {
+                "version": build_version,
+                "targets": [
+                    {
+                        "identifier": "revoke",
+                        "entries": [
+                            {"arch": "arm64", "addr": "10", "expected": "11", "asm": "22"}
+                        ],
+                    },
+                    {
+                        "identifier": "update",
+                        "entries": [
+                            {"arch": "x86_64", "addr": "20", "expected": "33", "asm": "44"}
+                        ],
+                    },
+                ],
+            }
+        ]
+        path = root / "patches.json"
+        path.write_text(json.dumps(config, ensure_ascii=False, indent=2), encoding="utf-8")
+        return path
+
+    def _make_fat_binary(self, slices: list[tuple[int, bytes]], *, fat64: bool) -> bytes:
+        return self._make_fat_binary_with_offsets(
+            [(cputype, data, offset) for (cputype, data), offset in zip(slices, [256, 1024], strict=False)],
+            fat64=fat64,
+        )
+
+    def _make_fat_binary_with_offsets(self, slices: list[tuple[int, bytes, int]], *, fat64: bool) -> bytes:
+        offsets = [256, 1024]
+        header = bytearray()
+        if fat64:
+            header.extend(struct.pack(">II", 0xCAFEBABF, len(slices)))
+            for cputype, data, offset in slices:
+                header.extend(struct.pack(">IIQQII", cputype, 0, offset, len(data), 0, 0))
+        else:
+            header.extend(struct.pack(">II", 0xCAFEBABE, len(slices)))
+            for cputype, data, offset in slices:
+                header.extend(struct.pack(">IIIII", cputype, 0, offset, len(data), 0))
+
+        blob = bytearray(header)
+        while slices and len(blob) < slices[0][2]:
+            blob.append(0)
+        for index, (_, data, offset) in enumerate(slices):
+            if len(blob) < offset:
+                blob.extend(b"\0" * (offset - len(blob)))
+            blob.extend(data)
+            if index + 1 < len(slices):
+                next_offset = slices[index + 1][2]
+                if len(blob) < next_offset:
+                    blob.extend(b"\0" * (next_offset - len(blob)))
+        return bytes(blob)
+
+    def _make_thin_macho(self, cputype: int, *, payload_seed: int) -> bytes:
+        total_size = 512
+        header = bytearray(struct.pack("<IIIIIIII", 0xFEEDFACF, cputype, 0, 0x2, 1, 72, 0, 0))
+        segment = bytearray()
+        segment.extend(struct.pack("<II", 0x19, 72))
+        segment.extend(b"__TEXT\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00")
+        segment.extend(struct.pack("<QQQQIIII", 0, total_size, 0, total_size, 7, 5, 0, 0))
+        blob = header + segment
+        while len(blob) < total_size:
+            blob.append((payload_seed + len(blob)) % 256)
+        return bytes(blob)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 背景 / Summary

Related to #55（不关闭 Intel 适配总任务）。

实体 **Intel x86_64 Mac / macOS 13.7.8 / WeChat 4.1.13 build 269630** 已用独立 runtime 完成防撤回验证，先测试隔离副本，再测试正式路径 `/Applications/WeChat.app`：

- **对方撤回**：原消息保留，显示 `[已拦截撤回]`。
- **自己撤回**：原消息正常移除，微信原生提示保留，不显示 `[已拦截撤回]`。

以上为测试者人工反馈；正式路径的 runtime 加载、hook 安装、expected bytes / trampoline RX readback 和 codesign 验签另有工具证据。

## 本 PR 内容

- `Scripts/experimental/intel-269630/`：与实机验收正式版本一致的 x86_64 runtime 源码快照、手写 assembly 夹具、受控 installer/wrapper 测试、无微信副作用的测试入口。
- Python 标准库只读 Intel preflight 与测试：区分 catalog 覆盖和实际运行验证。
- `Docs/intel-269630-runtime-tip.md`：原始 slice hash、UUID、parser/caller/字段地址及 expected bytes、签名和路径绑定经验、双路径验收及未验证项。
- `MAINTAINING.md` 索引。

没有上传微信二进制、payload、聊天记录、截图、账号、二维码、私人路径、IDA 数据库或原始日志。

## 已执行的测试

- [x] `python3 -B -m unittest discover -s Scripts/tests -p 'test_intel_preflight.py' -v`：15 tests passed。
- [x] `python3 -B Scripts/experimental/intel-269630/run_tests.py`：Debug / Release / ASan+UBSan，每次执行 100 个合成用例（5 类场景重复），Release 额外重复 5 次。
- [x] 同一测试入口编译真实构造函数并执行错误路径 dlopen 负例：明确拒绝、不安装 hook。
- [x] 物理 Intel 微信 269630 的隔离副本与正式安装路径双路径人工验收。
- [x] 正式 App `codesign --verify --deep --strict`；主程序原 entitlements 恢复并回读，保留 Sandbox / application-groups / allow-jit / Hardened Runtime，增加两个 runtime 所需权限。

## 为什么是 Draft / Scope and limitations

**这不是 GUI/CLI 已全面支持 Intel 的声明，也不是任意“最新版”均可用。** 不改 `patches.json`、SwiftPM targets、发布架构、runtime 支持列表或 ARM64 行为。

本机 Swift 5.8.1 低于项目要求；尚未完成全项目 Intel SwiftPM build/test。没有完成该 build 的完整 IDA/Hex-Rays 交叉确认，也没有实际回滚、麦克风/摄像头、全部消息类型/语言及长期稳定性验收。独立代码审查待完成。

原型仍需进一步审查结构解析、libc++ ABI、初始化时线程安全及本人撤回文案启发式。固定路径保护不应直接删掉；Staging payload 不能用于正式路径。没有自动安装器，测试脚本不会启动或修改微信。

App 已变为 ad-hoc，不再保留腾讯 Developer ID 身份。备份仅涵盖 App，不能保证账号或消息数据零风险。

## English

This draft contributes a tested **build-specific x86_64 runtime prototype**, synthetic tests and a field report for #55. Physical Intel testing on WeChat 4.1.13 **269630** confirmed both retaining another person's recalled message with a visible marker and preserving native self-recall behavior. It does not claim production GUI/CLI integration, compatibility with future builds, full disassembly review, or complete permissions/rollback validation. Maintainer feedback on integration and further review is welcome.
